### PR TITLE
Add basic README for installer tool

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -26,7 +26,7 @@ The Bitnami Production Runtime for Kubernetes builds on a default
 
    For example, to install onto GKE-1.9.x, use:
    ```sh
-   installer --platform gke-1.9
+   installer install --platform gke-1.9
    ```
 
    The installer may require some additional platform-specific

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,27 @@
+# Installer for Production Runtime
+
+Usage:
+
+```sh
+# Find supported platform
+installer list-platforms
+
+# Install to cluster given by current kubectl context
+installer install --platform=$platform
+```
+
+## Development
+
+Requires a typical golang development environment.  To build:
+
+```sh
+go get github.com/bitnami/kube-prod-runtime/installer
+```
+
+For local development against minikube:
+
+```sh
+minikube start --kubernetes-version=v1.9.0
+
+./installer -v install --platform=minikube-0.25+k8s-1.9 --manifests=../manifests
+```


### PR DESCRIPTION
Add basic installer how-to-golang README.

Also: fix a typo in the intro doc usage, noticed while writing the
same in installer README.