### PR TITLE
Add manifest validate/generate test.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,34 +1,72 @@
 // Force using our pod
 def label = UUID.randomUUID().toString()
 
-podTemplate(label: label,
+podTemplate(
+label: label,
+resourceLimitCpu: '2000m',
+resourceLimitMemory: '1Gi',
 containers: [
   containerTemplate(name: 'go1-10', image: 'golang:1.10.0', ttyEnabled: true, command: 'cat'),
-  containerTemplate(name: 'debian', image: 'debian:stretch', ttyEnabled: true, command: 'cat'),
+  containerTemplate(name: 'debian', image: 'bitnami/minideb:stretch', ttyEnabled: true, command: 'cat'),
 ]) {
 
   env.http_proxy = 'http://proxy.webcache'
 
   node(label) {
-    withEnv(["GOPATH+WS=${env.WORKSPACE}:/go"]) {
+    timeout(time: 30) {
       dir('src/github.com/bitnami/kube-prod-runtime') {
-        checkout scm
-
-        dir('installer') {
-          stage('Test installer') {
-            container('go1-10') {
-              sh 'go version'
-              sh 'make all vet test'
-            }
-          }
-
-          stage('Build installer release') {
-            container('go1-10') {
-              sh 'make release VERSION=$BUILD_TAG'
-              stash includes: 'release/installer', name: 'installer'
-            }
-          }
+        stage('Checkout') {
+          checkout scm
         }
+
+        parallel(
+        installer: {
+          dir('installer') {
+            container('go1-10') {
+              withEnv(["GOPATH+WS=${env.WORKSPACE}:/go"]) {
+                stage('Test installer') {
+                  sh 'go version'
+                  sh 'make all'
+                  sh 'make test'
+                  sh 'make vet'
+                }
+
+                stage('Build installer release') {
+                  sh 'make release VERSION=$BUILD_TAG'
+                  dir('release') {
+                    sh './installer --help'
+                    stash includes: 'installer', name: 'installer'
+                  }
+                }
+              }
+            }
+          }
+          //stash includes: 'tests/**', name: 'tests'
+        },
+        manifests: {
+          dir('manifests') {
+            container('debian') {
+              withEnv(["KUBECFG_JPATH+VALIDATE=${pwd()}/components:${pwd()}/lib",
+                       "KUBECFG=${env.WORKSPACE}/kubecfg"]) {
+                stage('Setup') {
+                  sh 'apt-get -qy update'
+                  sh 'apt-get -qy install wget ca-certificates make'
+                  sh 'wget -O $KUBECFG https://github.com/ksonnet/kubecfg/releases/download/v0.7.2/kubecfg-linux-amd64 && chmod +x $KUBECFG'
+                }
+
+                stage('Validate') {
+                  sh 'make validate KUBECFG="$KUBECFG -v"'
+                  stash includes: '**', name: 'manifests'
+                }
+
+                stage('Generate') {
+                  sh 'make all KUBECFG="$KUBECFG -v"'
+                  stash includes: 'platforms/*.yaml', name: 'yaml'
+                }
+              }
+            }
+          }
+        })
       }
     }
   }

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -2,7 +2,7 @@ VERSION = dev-$(shell date +%FT%T%z)
 
 GO = go
 GOFLAGS =
-GOBUILDFLAGS = $(GOFLAGS) -ldflags="-X main.version=$(VERSION)"
+GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION)'
 GORELEASEFLAGS = $(GOBUILDFLAGS) -tags netgo -installsuffix netgo
 GOTESTFLAGS = $(GOFLAGS) -race
 GOFMT = gofmt
@@ -15,10 +15,10 @@ GOPKGS = . ./cmd/... ./pkg/...
 all: $(BINDIR)/installer
 
 $(BINDIR)/installer: $(shell tools/godeps.sh .)
-	$(GO) build -o $@ $(GO_FLAGS) $(GO_BUILDFLAGS) .
+	$(GO) build -o $@ $(GOFLAGS) $(GOBUILDFLAGS) .
 
 release:
-	$(MAKE) release/installer BINDIR=release CGO_ENABLED=0 GOBUILDFLAGS="$(GO_RELEASEFLAGS)"
+	$(MAKE) release/installer BINDIR=release CGO_ENABLED=0 GOBUILDFLAGS="$(GORELEASEFLAGS)"
 
 test:
 	$(GO) test $(GOTESTFLAGS) $(GOPKGS)


### PR DESCRIPTION
The `kubecfg validate` step may become infeasible as-is, if it
requires substantially different server versions...