### PR TITLE
Enable bors-ng

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,12 @@
+status = [
+  "continuous-integration/jenkins/branch"
+]
+
+pr_status = [
+  "continuous-integration/jenkins/pr-merge"
+]
+
+#required_approvals = 1
+
+# Extend to 2h - default is 1h
+timeout_sec = 7200


### PR DESCRIPTION
Integration tests (will) take an unusually long time with this
project, so we want a bot to test overlapping changes and merge if ok,
and do that unattended.