### PR TITLE
Embiggen the VMs in the cluster

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -183,6 +183,8 @@ containers: [
                             --resource-group ${resourceGroup} \
                             --name ${name}                    \
                             --node-count 3                    \
+                            --node-vm-size Standard_DS2_v2    \
+                            --location eastus                 \
                             --kubernetes-version ${kversion}  \
                             --generate-ssh-keys                   \
                             --service-principal \$AZURE_CLIENT_ID \


### PR DESCRIPTION
I'm hitting what looks like memory/thrash issues killing nodes in my
test cluster, now that we're running heavier
workloads (elasticsearch).

This change shifts our test clusters from from 1cpu/3.5GiB to
2cpu/8GiB nodes.

https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/