### PR TITLE
[jjo] upgrade cert-manager to v0.3.0

### DIFF
--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -72,11 +72,11 @@ local kube = import "kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             default: kube.Container("cert-manager") {
-              image: "quay.io/jetstack/cert-manager-controller:v0.3.0",
+              image: "bitnami/cert-manager:0.3.0",
               args_+: {
                 "cluster-resource-namespace": "$(POD_NAMESPACE)",
                 "leader-election-namespace": "$(POD_NAMESPACE)",
-                "default-issuer-name": "letsencrypt-prod",
+                "default-issuer-name": $.letsencryptProd.metadata.name,
                 "default-issuer-kind": "ClusterIssuer",
               },
               env_+: {
@@ -95,7 +95,7 @@ local kube = import "kube.libsonnet";
     },
   },
 
-  letsencryptStaging: $.ClusterIssuer($.p+"letsencrypt-staging") + $.namespace {
+  letsencryptStaging: $.ClusterIssuer($.p+"letsencrypt-staging") {
     local this = self,
     spec+: {
       acme+: {


### PR DESCRIPTION
See http://docs.cert-manager.io/en/latest/admin/upgrading/upgrading-0.2-0.3.html

* upgraded main image from external v0.2.4 to Bitnami's v0.3.0
* removed cert-manager-ingress-shim as v0.3.0 has it built-in
* v0.3.0 uses `configmaps` instead of `endpoints` for leader election
* use ACME v02 for created ClusterIssuers
* ClusterIssuer is not namespaced 