### PR TITLE
Simplify podTemplate label

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@
 def label = UUID.randomUUID().toString()
 
 podTemplate(
-label: "${label} linux x86",
+label: label,
 idleMinutes: 1,  // Allow some best-effort reuse between successive stages
 containers: [
   containerTemplate(


### PR DESCRIPTION
Newer jenkins kubernetes plugin seems to pass this value on as k8s
labels (not just as jenkins node labels).  This restricts the available
character set (and doesn't support multiple space-separated values).