### PR TITLE
manifests: fix environment vars for bitnami/kibana:5.6.10-r9

### DIFF
--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -35,15 +35,9 @@ local strip_trailing_slash(s) = (
                 },
               },
               env_+: {
-                ELASTICSEARCH_URL: "http://%s:9200" % [$.es.svc.host],
-
-                local route = $.ingress.spec.rules[0].http.paths[0],
-                // Make sure we got the correct route
-                assert route.backend == $.svc.name_port,
-                SERVER_BASEPATH: strip_trailing_slash(route.path),
-                KIBANA_HOST: "0.0.0.0",
-                XPACK_MONITORING_ENABLED: "false",
-                XPACK_SECURITY_ENABLED: "false",
+                KIBANA_ELASTICSEARCH_URL: $.es.svc.host,
+                KIBANA_ELASTICSEARCH_PORT_NUMBER: "9200",
+                KIBANA_PORT_NUMBER: "5601",
               },
               ports_+: {
                 ui: { containerPort: 5601 },


### PR DESCRIPTION
Fixes kibana boot up

```console
INFO  ==> Starting kibana... 

{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:kibana@5.6.10","info"],"pid":51,"state":"green","message":"Status changed from uninitialized to green - Ready","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:elasticsearch@5.6.10","info"],"pid":51,"state":"yellow","message":"Status changed from uninitialized to yellow - Waiting for Elasticsearch","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["error","elasticsearch","admin"],"pid":51,"message":"Request error, retrying\nHEAD http://elasticsearch:9200/ => getaddrinfo ENOTFOUND elasticsearch elasticsearch:9200"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:console@5.6.10","info"],"pid":51,"state":"green","message":"Status changed from uninitialized to green - Ready","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"Unable to revive connection: http://elasticsearch:9200/"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"No living connections"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:elasticsearch@5.6.10","error"],"pid":51,"state":"red","message":"Status changed from yellow to red - Unable to connect to Elasticsearch at http://elasticsearch:9200.","prevState":"yellow","prevMsg":"Waiting for Elasticsearch"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:metrics@5.6.10","info"],"pid":51,"state":"green","message":"Status changed from uninitialized to green - Ready","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","plugin:timelion@5.6.10","info"],"pid":51,"state":"green","message":"Status changed from uninitialized to green - Ready","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["listening","info"],"pid":51,"message":"Server running at http://0.0.0.0:5601"}
{"type":"log","@timestamp":"2018-06-27T07:52:24Z","tags":["status","ui settings","error"],"pid":51,"state":"red","message":"Status changed from uninitialized to red - Elasticsearch plugin is red","prevState":"uninitialized","prevMsg":"uninitialized"}
{"type":"log","@timestamp":"2018-06-27T07:52:27Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"Unable to revive connection: http://elasticsearch:9200/"}
{"type":"log","@timestamp":"2018-06-27T07:52:27Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"No living connections"}
{"type":"log","@timestamp":"2018-06-27T07:52:29Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"Unable to revive connection: http://elasticsearch:9200/"}
{"type":"log","@timestamp":"2018-06-27T07:52:29Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"No living connections"}
{"type":"log","@timestamp":"2018-06-27T07:52:32Z","tags":["warning","elasticsearch","admin"],"pid":51,"message":"Unable to revive connection: http://elasticsearch:9200/"}
```