### PR TITLE
Revert "Switch to using elasticsearch image from Bitnami."

### DIFF
--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -2,7 +2,7 @@ local kube = import "kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.4-r58";
+local ELASTICSEARCH_IMAGE = "k8s.gcr.io/elasticsearch:v5.6.4";
 
 {
   p:: "",


### PR DESCRIPTION
This reverts commit 101fa2124382f143d2df1eefdc05edba636015cf. With that commit I broke clustering and data persistence. Until I find a way to restore such functionality, let's roll back to using upstream image.