### PR TITLE
manifests: adds `--txt-owner-id` argument to `external-dns` launch

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -27,6 +27,8 @@ local kube = import "kube.libsonnet";
   sa: kube.ServiceAccount($.p+"external-dns") + $.namespace,
 
   deploy: kube.Deployment($.p+"external-dns") + $.namespace {
+    local this = self,
+    ownerId:: error "ownerId is required",
     spec+: {
       template+: {
         spec+: {
@@ -36,6 +38,7 @@ local kube = import "kube.libsonnet";
               image: "registry.opensource.zalan.do/teapot/external-dns:v0.5.0",
               args_+: {
                 sources_:: ["service", "ingress"],
+                "txt-owner-id": this.ownerId,
                 //"domain-filter": "example.com",
               },
               args+: ["--source=%s" % s for s in self.args_.sources_],

--- a/manifests/platforms/aks-common.libsonnet
+++ b/manifests/platforms/aks-common.libsonnet
@@ -20,6 +20,7 @@ local kibana = import "kibana.jsonnet";
     },
 
     deploy+: {
+      ownerId: $.external_dns_zone_name,
       spec+: {
         template+: {
           spec+: {


### PR DESCRIPTION
The `--txt-owner-id` is set to the value of dns_zone. Closes #71