### PR TITLE
manifests: apply `elasticsearch` serviceAccountName to `elasticsearch` statefulset.

### DIFF
--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -43,6 +43,7 @@ local ELASTICSEARCH_IMAGE = "k8s.gcr.io/elasticsearch:v5.6.4";
           },
         },
         spec+: {
+          serviceAccountName: $.serviceAccount.metadata.name,
           affinity: {
             podAntiAffinity: {
               preferredDuringSchedulingIgnoredDuringExecution: [


### PR DESCRIPTION
To fix the service dscovery in elasticsearch

```
# k -n kube-system  logs elasticsearch-logging-0 -c elasticsearch
+ export NODE_NAME=elasticsearch-logging-0
+ NODE_NAME=elasticsearch-logging-0
+ export NODE_MASTER=true
+ NODE_MASTER=true
+ export NODE_DATA=true
+ NODE_DATA=true
+ export HTTP_PORT=9200
+ HTTP_PORT=9200
+ export TRANSPORT_PORT=9300
+ TRANSPORT_PORT=9300
+ export MINIMUM_MASTER_NODES=2
+ MINIMUM_MASTER_NODES=2
+ chown -R elasticsearch:elasticsearch /data
+ ./bin/elasticsearch_logging_discovery
F0706 05:28:10.968063       8 elasticsearch_logging_discovery.go:78] kube-system namespace doesn't exist: namespaces "kube-system" is forbidden: User "system:serviceaccount:kube-system:default" cannot get namespaces in the namespace "kube-system"
goroutine 1 [running]:
k8s.io/kubernetes/vendor/github.com/golang/glog.stacks(0xc42028db00, 0xc4205a0000, 0xf7, 0x1bb)
    /go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:766 +0xcf
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).output(0x1a38100, 0xc400000003, 0xc4200982c0, 0x1994cf4, 0x22, 0x4e, 0x0)
    /go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:717 +0x322
k8s.io/kubernetes/vendor/github.com/golang/glog.(*loggingT).printf(0x1a38100, 0x3, 0x121acfe, 0x1e, 0xc42069bf50, 0x2, 0x2)
    /go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:655 +0x14c
k8s.io/kubernetes/vendor/github.com/golang/glog.Fatalf(0x121acfe, 0x1e, 0xc42069bf50, 0x2, 0x2)
    /go/src/k8s.io/kubernetes/vendor/github.com/golang/glog/glog.go:1145 +0x67
main.main()
    /go/src/k8s.io/kubernetes/cluster/addons/fluentd-elasticsearch/es-image/elasticsearch_logging_discovery.go:78 +0xbef
```