### PR TITLE
Switch to using `bitnami/external-dns` for External DNS.

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -12,9 +12,19 @@ local kube = import "../lib/kube.libsonnet";
         verbs: ["get", "watch", "list"],
       },
       {
+        apiGroups: [""],
+        resources: ["pods"],
+        verbs: ["get","watch","list"],
+      },
+      {
         apiGroups: ["extensions"],
         resources: ["ingresses"],
         verbs: ["get", "watch", "list"],
+      },
+      {
+        apiGroups: [""],
+        resources: ["nodes"],
+        verbs: ["list"],
       },
     ],
   },
@@ -35,7 +45,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             edns: kube.Container("external-dns") {
-              image: "registry.opensource.zalan.do/teapot/external-dns:v0.5.0",
+              image: "bitnami/external-dns:0.5.4-r8",
               args_+: {
                 sources_:: ["service", "ingress"],
                 "txt-owner-id": this.ownerId,


### PR DESCRIPTION
Switches to using Bitnami image for External DNS, plus a couple of RBAC changes required when upgrading from 0.5.0 to 0.5.4 (as per External DNS documentation).