### PR TITLE
ci: stop storing go-build cache to reduce test flakiness

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,7 @@ def withGo(Closure body) {
             "PATH+GOBIN=${env.WORKSPACE}/bin",
             "HOME=${env.WORKSPACE}",
         ]) {
-            cache(maxCacheSize: 1000, caches: [
-                [$class: 'ArbitraryFileCache', path: "${env.HOME}/.cache/go-build"],
-            ]) {
-                body()
-            }
+            body()
         }
     }
 }


### PR DESCRIPTION
using the jobcacher plugin to store the go-build cache can cause flakiness while processing concurrent builds. 