### PR TITLE
Make root manifest generation code non AKS-specific.

### DIFF
--- a/kubeprod/pkg/aks/aks.go
+++ b/kubeprod/pkg/aks/aks.go
@@ -16,8 +16,6 @@ import (
 const (
 	// AppID is the registered ID of the "Kubeprod Installer" app
 	AppID = "2dcc87f0-6e30-4dca-b572-20d971c63a89"
-	// AksRootManifest specifies the filename of the root (cluster) manifest
-	AksRootManifest = "kube-system.jsonnet"
 )
 
 // NewAuthorizerFromCli snarfs credentials from azure-cli's

--- a/kubeprod/pkg/aks/platform.go
+++ b/kubeprod/pkg/aks/platform.go
@@ -158,10 +158,6 @@ func base64RandBytes(n uint) (string, error) {
 	return base64.StdEncoding.EncodeToString(buf), nil
 }
 
-func Generate(manifestsPath string, platformName string) error {
-	return WriteRootManifest(manifestsPath, platformName)
-}
-
 func PreUpdate(origConfig interface{}, contactEmail string) (interface{}, error) {
 	ctx := context.TODO()
 

--- a/kubeprod/pkg/installer/install.go
+++ b/kubeprod/pkg/installer/install.go
@@ -114,7 +114,7 @@ func (c InstallCmd) Run(out io.Writer) error {
 	}
 
 	log.Info("Generating root manifest for platform ", c.Platform.Name)
-	if err := c.Platform.RunGenerate(c.ManifestBase.Path, c.Platform.Name); err != nil {
+	if err := prodruntime.WriteRootManifest(c.ManifestBase.Path, c.Platform.Name); err != nil {
 		return err
 	}
 

--- a/kubeprod/pkg/prodruntime/manifest.go
+++ b/kubeprod/pkg/prodruntime/manifest.go
@@ -1,4 +1,4 @@
-package aks
+package prodruntime
 
 import (
 	"bufio"
@@ -9,13 +9,16 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const clusterTemplate = `# Cluster-specific configuration
-
+const (
+	clusterTemplate = `# Cluster-specific configuration
 (import "{{.ManifestsPath}}platforms/{{.Platform}}.jsonnet") {
-	config:: import "{{.AksConfig}}",
+	config:: import "{{.ConfigFilePath}}",
 	// Place your overrides here
-}
-`
+}`
+
+	// RootManifest specifies the filename of the root (cluster) manifest
+	RootManifest = "kube-system.jsonnet"
+)
 
 // WriteRootManifest executes the template from the `clusterTemplate`
 // variable and writes the result as the root (cluster) manifest in
@@ -23,16 +26,16 @@ const clusterTemplate = `# Cluster-specific configuration
 func WriteRootManifest(manifestsBase string, platform string) error {
 	// If the output file already exists do not overwrite it.
 	v := map[string]string{
-		"AksConfig":     "./kubeprod.json",
-		"ManifestsPath": manifestsBase,
-		"Platform":      platform,
+		"ConfigFilePath": "kubeprod.json",
+		"ManifestsPath":  manifestsBase,
+		"Platform":       platform,
 	}
-	f, err := os.OpenFile(AksRootManifest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0777)
+	f, err := os.OpenFile(RootManifest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0777)
 	if err != nil {
 		if os.IsExist(err) {
-			log.Warning("Will not overwrite already existing output file: ", AksRootManifest)
+			log.Warning("Will not overwrite already existing output file: ", RootManifest)
 		} else {
-			return fmt.Errorf("unable to write to %q: %v", AksRootManifest, err)
+			return fmt.Errorf("unable to write to %q: %v", RootManifest, err)
 		}
 	}
 	defer f.Close()

--- a/kubeprod/pkg/prodruntime/platforms.go
+++ b/kubeprod/pkg/prodruntime/platforms.go
@@ -12,7 +12,6 @@ import (
 type Platform struct {
 	Name        string
 	Description string
-	Generate    func(manifestPath string, platformName string) error
 	PreUpdate   func(config interface{}, contactEmail string) (interface{}, error)
 	PostUpdate  func(conf *restclient.Config) error
 }
@@ -29,13 +28,11 @@ var Platforms = []Platform{
 	{
 		Name:        "aks+k8s-1.9",
 		Description: "Azure Container Service (AKS) with Kubernetes 1.9",
-		Generate:    aks.Generate,
 		PreUpdate:   aks.PreUpdate,
 	},
 	{
 		Name:        "aks+k8s-1.8",
 		Description: "Azure Container Service (AKS) with Kubernetes 1.8",
-		Generate:    aks.Generate,
 		PreUpdate:   aks.PreUpdate,
 	},
 }
@@ -52,13 +49,6 @@ func FindPlatform(name string) *Platform {
 
 func (p *Platform) ManifestURL(base *url.URL) (*url.URL, error) {
 	return base.Parse(fmt.Sprintf("platforms/%s.jsonnet", p.Name))
-}
-
-func (p *Platform) RunGenerate(manifestsPath string, platformName string) error {
-	if p.Generate == nil {
-		return nil
-	}
-	return p.Generate(manifestsPath, platformName)
 }
 
 func (p *Platform) RunPreUpdate(kubeprodConf interface{}, contactEmail string) (interface{}, error) {


### PR DESCRIPTION
Code used to generate root manifest is not AKS specific. Hence, move it outside the `aks`package package into the `prodruntime` package.