### PR TITLE
Use Bitnami image for Prometheus.

### DIFF
--- a/manifests/lib/utils.libsonnet
+++ b/manifests/lib/utils.libsonnet
@@ -3,6 +3,13 @@
 local kube = import "kube.libsonnet";
 
 {
+  trimUrl(str):: (
+    if std.endsWith(str, "/") then
+      std.substr(str, 1, std.length(str) - 1)
+    else
+      str
+  ),
+
   toJson(x):: (
     if std.type(x) == "string" then std.escapeStringJson(x)
     else std.toString(x)


### PR DESCRIPTION
This change also fixes the ConfigMap reloader which was broken because the URL specified in the `webhook-url` had too many slashes in it.