### PR TITLE
adds tests to validate if load balancer is assigned a public ip

### DIFF
--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -181,7 +181,11 @@ var _ = Describe("Ingress", func() {
 
 				for _, lbIng := range ing2.Status.LoadBalancer.Ingress {
 					if lbIng.Hostname != "" {
-						lbAddr = lbIng.Hostname
+						addrs, err := net.LookupHost(lbIng.Hostname)
+						if err != nil {
+							return "", err
+						}
+						lbAddr = addrs[0]
 					} else if lbIng.IP != "" && lbAddr == "" {
 						lbAddr = lbIng.IP
 					}


### PR DESCRIPTION
The ingress loadbalancer test is split out from the existing http test and if used to validate if the service has an public ip address. 

