### PR TITLE
fix sed command to use LetsEncrypt staging environment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,7 +185,7 @@ spec:
 
                                     // Set the default LetsEncrypt issuer to staging in tests to avoid LE ratelimits
                                     // A better way to do this would be to override the default jsonnet config
-                                    sh 'sed -i "s/\"default-issuer-name\": .*,/\"default-issuer-name\": $.letsencryptStaging.metadata.name,/" components/cert-manager.jsonnet'
+                                    sh 'sed -i \'s/"default-issuer-name": .*,/"default-issuer-name": \$.letsencryptStaging.metadata.name,/\' components/cert-manager.jsonnet'
                                 }
                                 stash includes: 'manifests/**', excludes: 'manifests/Makefile', name: 'manifests'
                             }


### PR DESCRIPTION
The sed command to use the LetsEncrypt staging environment was not being 
interpreted correctly by the Jenkinsfile. As a result the production 
environment was being used and we have started noticing rate limiting issues 
and hence the we have been seeing failure in the tests.

This PR modifies the sed command specification to that it's correctly interpreted 
by the Jenkinsfile and the LetsEncrypt staging environment is used in the tests.