### PR TITLE
aks: add addon-manager label in order to not reconcile heapster deployment

### DIFF
--- a/manifests/platforms/aks-common.libsonnet
+++ b/manifests/platforms/aks-common.libsonnet
@@ -83,7 +83,18 @@ local kibana = import "../components/kibana.jsonnet";
     },
   },
 
-  heapster: heapster,
+  heapster: heapster {
+    deployment+: {
+      metadata+: {
+        labels+: {
+          // The heapster pod was constantly being relaunched delaying the rollout on AKS
+          // adding the // addon-manager label "EnsureExists" works around this issue
+          // monitor https://github.com/Azure/ACS/issues/49 for issue resolution in AKS
+          "addonmanager.kubernetes.io/mode": "EnsureExists",
+        },
+      },
+    },
+  },
 
   prometheus: prometheus {
     ingress+: {


### PR DESCRIPTION
I was noticing that the heapster deployment was taking too long rollout
because the heapster pod was constantly being relaunched. According to
https://github.com/Azure/acs-engine/pull/1133 the workaround to this
issue is to apply the `addonmanager.kubernetes.io/mode: EnsureExists`
label on the heapster deployment.

related: https://github.com/Azure/ACS/issues/49