### PR TITLE
Minor updates to AKS quickstart.md.

### DIFF
--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -134,7 +134,7 @@ Before running `kubeprod` to bootstrap BKPR, create a directory where `kubeprod`
 * `kube-system.jsonnet`: the cluster-specific entry point which is used by `kubeprod` and `kubecfg`
 * `kubeprod.json`: a JSON configuration file for the cluster. This file might contain sensitive information (secrets, passwords, tokens, etc.) so it is highly recommended to not store it under any revision control system.
 
-When `kubeprod` runs, it performs some platform-specific steps. For example, when bootstrapping BKPR in AKS (Azure Kubernetes), `kubeprod` will create some objects in Azure. Please read [Azure objects in BKPR](aks/objects.md) for additional information on which objects are created as part of the cluster bootstrap process.
+When `kubeprod` runs, it performs some platform-specific steps. For example, when bootstrapping BKPR in AKS (Azure Kubernetes), `kubeprod` will create some objects in Azure.
 
 Afterwards, `kubeprod` generates the `kube-system.jsonnet` and `kubeprod.json` files and then will perform a `kubecfg update` using the cluster-specific `kube-system.jsonnet` file generated as the entry point.
 


### PR DESCRIPTION
As of Go 1.8, the default $GOPATH is $HOME/go (and not $HOME/gopath).
Hint the user at the path for the manifests.
Reference docs/aks/objects.md which will describe the Azure objects created by `kubeprod`.
Other minor edits.