### PR TITLE
Switch from Bitnami elasticsearch-prod:6 image to elasticsearch:5

### DIFF
--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -2,7 +2,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = "tompizmor/elasticsearch:6";
+local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.4-r55";
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -2,8 +2,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local KIBANA_IMAGE = "bitnami/kibana:6.3.2-r8";
-
+local KIBANA_IMAGE = "bitnami/kibana:5.6.11-r18";
 
 local strip_trailing_slash(s) = (
   if std.endsWith(s, "/") then


### PR DESCRIPTION
Rationale is that we are abandoning the `elasticsearch-prod` image in favor of the new variant `elasticsearch` that does not rely on the nami components but shell script and is closer to upstream.