### PR TITLE
added smoke tests for elasticsearch logging

### DIFF
--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/api/core/v1"
 	xv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -73,21 +72,6 @@ func httpClient(hosts *map[string]string) (*http.Client, error) {
 	return &http.Client{Transport: transport}, nil
 }
 
-func DecodeFile(decoder runtime.Decoder, path string) (runtime.Object, error) {
-	buf, err := ioutil.ReadFile(path)
-	if err != nil {
-		return nil, err
-	}
-	obj, _, err := decoder.Decode(buf, nil, nil)
-	return obj, err
-}
-
-func DecodeFileOrDie(decoder runtime.Decoder, path string) runtime.Object {
-	obj, err := DecodeFile(decoder, path)
-	Expect(err).NotTo(HaveOccurred())
-	return obj
-}
-
 func statusCode(resp *http.Response) int {
 	return resp.StatusCode
 }
@@ -137,11 +121,11 @@ var _ = Describe("Ingress", func() {
 
 		decoder := scheme.Codecs.UniversalDeserializer()
 
-		deploy = DecodeFileOrDie(decoder, "testdata/ingress-deploy.yaml").(*appsv1beta1.Deployment)
+		deploy = decodeFileOrDie(decoder, "testdata/ingress-deploy.yaml").(*appsv1beta1.Deployment)
 
-		svc = DecodeFileOrDie(decoder, "testdata/ingress-service.yaml").(*v1.Service)
+		svc = decodeFileOrDie(decoder, "testdata/ingress-service.yaml").(*v1.Service)
 
-		ing = DecodeFileOrDie(decoder, "testdata/ingress-ingress.yaml").(*xv1beta1.Ingress)
+		ing = decodeFileOrDie(decoder, "testdata/ingress-ingress.yaml").(*xv1beta1.Ingress)
 
 		suffix := *dnsSuffix
 		if suffix == "" {

--- a/tests/integration_suite_test.go
+++ b/tests/integration_suite_test.go
@@ -3,6 +3,7 @@ package integration
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,6 +18,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	// For client auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -65,6 +68,21 @@ func deleteNsOrDie(c corev1.NamespacesGetter, ns string) {
 	if err != nil {
 		panic(err.Error())
 	}
+}
+
+func decodeFile(decoder runtime.Decoder, path string) (runtime.Object, error) {
+	buf, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	obj, _, err := decoder.Decode(buf, nil, nil)
+	return obj, err
+}
+
+func decodeFileOrDie(decoder runtime.Decoder, path string) runtime.Object {
+	obj, err := decodeFile(decoder, path)
+	Expect(err).NotTo(HaveOccurred())
+	return obj
 }
 
 func TestE2e(t *testing.T) {

--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -1,0 +1,93 @@
+package integration
+
+import (
+	"encoding/json"
+	"math/rand"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func RandString(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
+}
+
+type hits struct {
+	Total int `json:"total`
+}
+
+type apiResponse struct {
+	Hits hits `json:"hits"`
+}
+
+func totalHits(resp *apiResponse) int {
+	return resp.Hits.Total
+}
+
+// This test uses https://onsi.github.io/ginkgo/ - see there for docs
+// on the slightly odd structure this imposes.
+var _ = Describe("Logging", func() {
+	var c kubernetes.Interface
+	var deploy *appsv1beta1.Deployment
+	var ns string
+
+	BeforeEach(func() {
+		c = kubernetes.NewForConfigOrDie(clusterConfigOrDie())
+		ns = createNsOrDie(c.CoreV1(), "test-logging-")
+
+		decoder := scheme.Codecs.UniversalDeserializer()
+
+		deploy = decodeFileOrDie(decoder, "testdata/logging-deploy.yaml").(*appsv1beta1.Deployment)
+
+		deploy.Spec.Template.Spec.Containers[0].Env[0].Value = RandString(32)
+	})
+
+	AfterEach(func() {
+		// disable namespace deletion due to timeout issue experienced on AKS, TODO: re-enable
+		// deleteNsOrDie(c.CoreV1(), ns)
+	})
+
+	JustBeforeEach(func() {
+		var err error
+		deploy, err = c.AppsV1beta1().Deployments(ns).Create(deploy)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("basic", func() {
+		// We create a container that repeatedly writes out a log signature to the
+		// standard output and this test executes a query on elasticsearch to look up
+		// the log signature
+		It("should capture container logs", func() {
+			Eventually(func() (*apiResponse, error) {
+				var err error
+				selector := "log:" + deploy.Spec.Template.Spec.Containers[0].Env[0].Value
+				params := map[string]string{"q": selector}
+				resultRaw, err := c.CoreV1().Services(metav1.NamespaceSystem).ProxyGet("http", "elasticsearch-logging", "9200", "_search", params).DoRaw()
+				if err != nil {
+					return nil, err
+				}
+
+				resp := apiResponse{}
+				json.Unmarshal(resultRaw, &resp)
+				return &resp, err
+			}, "5m", "5s").
+				Should(WithTransform(totalHits, BeNumerically(">", 0)))
+		})
+	})
+})

--- a/tests/testdata/logging-deploy.yaml
+++ b/tests/testdata/logging-deploy.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: echolog
+  labels:
+    name: echolog
+spec:
+  template:
+    metadata:
+      labels:
+        name: echolog
+    spec:
+      containers:
+        - name: echolog
+          image: busybox
+          command:
+          - sh
+          - -c
+          - while true; do echo "$LOG_SIGNATURE"; sleep 1; done
+          env:
+          - name: LOG_SIGNATURE
+            value: dummy


### PR DESCRIPTION
To test elasticsearch logging we create a container that repeatedly
writes out a log signature (a random string) to the containers stdout.
The test then executes a query to the elasticsearch api to find the
expected log signature