### PR TITLE
tests: bump up timeout for logging test

### DIFF
--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Logging", func() {
 				resp := apiResponse{}
 				json.Unmarshal(resultRaw, &resp)
 				return &resp, err
-			}, "5m", "5s").
+			}, "15m", "5s").
 				Should(WithTransform(totalHits, BeNumerically(">", 0)))
 		})
 	})


### PR DESCRIPTION
the elasticsearch cluster takes a while to come up and we don't have
a nice way to determine if the elasticsearch statefulset is ready.