### PR TITLE
manifests: fix data mountpoint location for elasticsearch pods

### DIFF
--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -5,7 +5,7 @@ local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.4-r55";
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
-local ELASTICSEARCH_DATA_MOUNTPOINT = "/opt/bitnami/elasticsearch/data";
+local ELASTICSEARCH_DATA_MOUNTPOINT = "/bitnami/elasticsearch/data";
 
 // Mount point for the custom Java security properties configuration file
 local JAVA_SECURITY_MOUNTPOINT = "/opt/bitnami/java/lib/security/java.security.custom";


### PR DESCRIPTION
The data volume for pods in the ES statefulset were wrongly being mounted at `/opt/bitnami/elasticsearch/data`. According to https://github.com/bitnami/bitnami-docker-elasticsearch#persisting-your-application the correct location for mounting the persistent volume is `/bitnami/elasticsearch/data`.

At a result of this misconfiguration the pods would quickly run out of storage space, as a result of which logs would no longer be captured by ES.

![screenshot_2018-09-25 kibana](https://user-images.githubusercontent.com/410147/45991544-058b0800-c0a3-11e8-95ae-10f7827f7b50.png)

Sure enough Elasticsearch made tracking down this issue easy :tada: 

```
{
  "_index": "logstash-2018.09.24",
  "_type": "fluentd",
  "_id": "AWYMti91lDGNPn6P-Hoy",
  "_version": 1,
  "_score": null,
  "_source": {
    "log": "[2018-09-24T17:49:57,661][INFO ][o.e.c.r.a.DiskThresholdMonitor] [elasticsearch-logging-2] low disk watermark [85%] exceeded on [RUK0ZgA2T7G-EdIFXf23NA][elasticsearch-logging-2][/bitnami/elasticsearch/data/nodes/0] free: 3.6gb[12.6%], replicas will not be assigned to this node\n",
    "stream": "stdout",
    "docker": {
      "container_id": "f6d9e9223c4e9738f47c4f17dd32f21ec9b2b077bc52ef7b19082af7a5cc2534"
    },
    "kubernetes": {
      "container_name": "elasticsearch-logging",
      "namespace_name": "kube-system",
      "pod_name": "elasticsearch-logging-2",
      "container_image": "bitnami/elasticsearch:5.6.4-r55",
      "container_image_id": "docker-pullable://bitnami/elasticsearch@sha256:ecaf1917a3e85d9a941a88d9acb9649b6822ff04fc7e2a7040309e3727af11b3",
      "pod_id": "885aefe4-bfc5-11e8-ae51-c2dbfc624ec7",
      "labels": {
        "controller-revision-hash": "elasticsearch-logging-59466568cd",
        "k8s-app": "elasticsearch-logging",
        "name": "elasticsearch-logging",
        "statefulset_kubernetes_io/pod-name": "elasticsearch-logging-2"
      },
      "host": "aks-nodepool1-33760494-0",
      "master_url": "https://10.0.0.1:443/api",
      "namespace_id": "3469c153-bfc3-11e8-ae51-c2dbfc624ec7"
    },
    "@timestamp": "2018-09-24T17:49:57.661636847+00:00",
    "tag": "kubernetes.var.log.containers.elasticsearch-logging-2_kube-system_elasticsearch-logging-f6d9e9223c4e9738f47c4f17dd32f21ec9b2b077bc52ef7b19082af7a5cc2534.log"
  },
  "fields": {
    "@timestamp": [
      1537811397661
    ]
  },
  "sort": [
    1537811397661
  ]
}
```