### PR TITLE
configure `securityContext.fsGroup` for alertmanager mount points

### DIFF
--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -308,6 +308,7 @@ local get_cm_web_hook_url = function(port, path) (
               templates: kube.ConfigMapVolume(am.templates),
             },
             securityContext+: {
+              runAsUser: 1001,
               fsGroup: 1001,
             },
             containers_+: {


### PR DESCRIPTION
`bitnami/alertmanager` image is a non-root image launched with id `1001`
by default. In order to ensure that the alertmanager process is able to
write into the data volumes we need to configure the filesyste security
context.

This change resolves the following errors observed in the alertmanager logs.

```
level=info ts=2018-09-26T08:57:38.869769208Z caller=silence.go:271 component=silences msg="Maintenance done" duration=820.402µs size=0
level=info ts=2018-09-26T08:57:38.869801208Z caller=silence.go:298 component=silences msg="Running maintenance failed" err="open /alertmanager/silences.945fcdd893a310f: permission denied"
```