### PR TITLE
tests: restore post-test namespace deletion

### DIFF
--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -135,8 +135,7 @@ var _ = Describe("Ingress", func() {
 	})
 
 	AfterEach(func() {
-		// disable namespace deletion due to timeout issue experienced on AKS, TODO: re-enable
-		// deleteNsOrDie(c.CoreV1(), ns)
+		deleteNs(c.CoreV1(), ns)
 	})
 
 	JustBeforeEach(func() {

--- a/tests/integration_suite_test.go
+++ b/tests/integration_suite_test.go
@@ -70,6 +70,19 @@ func deleteNsOrDie(c corev1.NamespacesGetter, ns string) {
 	}
 }
 
+// `deleteNs`  attempts to delete a namespace without panicing on errors.
+// Generally `deleteNsOrDie` should be used for the namespace deletion, but is
+// known to fail on AKS due to connection timeout issues.
+func deleteNs(c corev1.NamespacesGetter, ns string) {
+	if ns == "" {
+		return
+	}
+	err := c.Namespaces().Delete(ns, &metav1.DeleteOptions{})
+	if err != nil {
+		fmt.Println(err.Error())
+	}
+}
+
 func decodeFile(decoder runtime.Decoder, path string) (runtime.Object, error) {
 	buf, err := ioutil.ReadFile(path)
 	if err != nil {

--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -58,8 +58,7 @@ var _ = Describe("Logging", func() {
 	})
 
 	AfterEach(func() {
-		// disable namespace deletion due to timeout issue experienced on AKS, TODO: re-enable
-		// deleteNsOrDie(c.CoreV1(), ns)
+		deleteNs(c.CoreV1(), ns)
 	})
 
 	JustBeforeEach(func() {

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Monitoring", func() {
 	})
 
 	AfterEach(func() {
-		// deleteNsOrDie(c.CoreV1(), ns)
+		deleteNs(c.CoreV1(), ns)
 	})
 
 	JustBeforeEach(func() {


### PR DESCRIPTION
Instead of disabling the namespace deletion in the post-test setup, we stop 
panicking when the namespace deletion fails

`deleteNs`  attempts to delete a namespace without panicing on errors.
Generally `deleteNsOrDie` should be used for the namespace deletion, but is
known to fail on AKS due to connection timeout issues.