### PR TITLE
manifests: sync elasticsearch and kibana versions

### DIFF
--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -1,7 +1,7 @@
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.4-r55";
+local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.12-r2";
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -2,7 +2,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local KIBANA_IMAGE = "bitnami/kibana:5.6.11-r18";
+local KIBANA_IMAGE = "bitnami/kibana:5.6.12-r15";
 
 local strip_trailing_slash(s) = (
   if std.endsWith(s, "/") then


### PR DESCRIPTION
Kibana expects to be on the same version as Elasticsearch as reported by
the following kibana log message.

```
You're running Kibana 5.6.11 with some different versions of Elasticsearch. Update Kibana or Elasticsearch to the same version to prevent compatibility issues: v5.6.4
```