### PR TITLE
kubeprod: adds `version` subcommand to print installer version

### DIFF
--- a/kubeprod/cmd/version.go
+++ b/kubeprod/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var Version = "(dev build)"
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		out := cmd.OutOrStdout()
+
+		fmt.Fprintf(out, "Installer Version: %s\n", Version)
+
+		return nil
+	},
+}

--- a/kubeprod/main.go
+++ b/kubeprod/main.go
@@ -19,6 +19,8 @@ import (
 var version = "(dev build)"
 
 func main() {
+	cmd.Version = version
+
 	if err := cmd.RootCmd.Execute(); err != nil {
 		// PersistentPreRunE may not have been run for early
 		// errors, like invalid command line flags.


### PR DESCRIPTION
The `version` command prints the installer version as specified 
at the time of the build.