### PR TITLE
Makefile: error out if `jq` is not installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ endif
 ifndef HAS_JQ
 	$(error You must install jq)
 endif
-	@PREV_VERSION=$$(git -c 'versionsort.suffix=-' tag --list  --sort=-v:refname | grep -m2 "^v[0-9]*\.[0-9]*\.[0-9]*$$" | tail -n1) ; \
+	@set -e ; \
+	PREV_VERSION=$$(git -c 'versionsort.suffix=-' tag --list  --sort=-v:refname | grep -m2 "^v[0-9]*\.[0-9]*\.[0-9]*$$" | tail -n1) ; \
 	echo -n > jenkins/Changes.lst ; \
 	for pr in $$(git log $${PREV_VERSION}..$(VERSION) --pretty=format:"%s" | grep "Merge pull request" | cut -d"#" -f2 | cut -d' ' -f1); do \
 		wget -q --header "Authorization: token $${GITHUB_TOKEN}" "https://api.github.com/repos/$(GITHUB_USER)/$(GITHUB_REPO)/pulls/$${pr}" -O - | \
@@ -41,6 +42,7 @@ ifndef GITHUB_TOKEN
 endif
 	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' || :
 	cat Release_Notes.md | github-release release --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' -n 'BKPR $(VERSION)' -d -
+	@set -e ; \
 	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' --name "$$(basename $${f})" --file "$${f}" ; done
 
 clean:

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -22,7 +22,8 @@ $(BINDIR)/$(PACKAGE): $(shell tools/godeps.sh .)
 	$(GO) build -o $@ $(GOFLAGS) $(GOBUILDFLAGS) .
 
 release: clean
-	@for platform in $(TARGETS); do \
+	@set -e ; \
+	for platform in $(TARGETS); do \
 		GOOS=$${platform%/*} ; \
 		GOARCH=$${platform#*/} ; \
 		ARTIFACTS_DIR=_dist/$${GOOS}-$${GOARCH}/bkpr-$(VERSION) ; \
@@ -33,7 +34,8 @@ release: clean
 	done
 
 manifests: release
-	@for platform in $(TARGETS); do \
+	@set -e ; \
+	for platform in $(TARGETS); do \
 		GOOS=$${platform%/*} ; \
 		GOARCH=$${platform#*/} ; \
 		ARTIFACTS_DIR=_dist/$${GOOS}-$${GOARCH}/bkpr-$(VERSION) ; \
@@ -45,7 +47,8 @@ manifests: release
 	done
 
 dist: archiver release manifests
-	@for platform in $(TARGETS); do \
+	@set -e ; \
+	for platform in $(TARGETS); do \
 		GOOS=$${platform%/*} ; \
 		GOARCH=$${platform#*/} ; \
 		ARTIFACTS_DIR=_dist/$${GOOS}-$${GOARCH}/bkpr-$(VERSION) ; \


### PR DESCRIPTION
The `jq` tool is required to execute the release-notes makefile target,
error out with a message when it's not installed.