### PR TITLE
releases: mark rc releases as pre-releases in github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ ifndef GITHUB_TOKEN
 	$(error You must specify the GITHUB_TOKEN)
 endif
 	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' || :
-	cat Release_Notes.md | github-release release --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' -n 'BKPR $(VERSION)' -d -
 	@set -e ; \
+	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' -n 'BKPR $(VERSION)' -d -
 	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' --name "$$(basename $${f})" --file "$${f}" ; done
 
 clean:


### PR DESCRIPTION
If the git tag is marked as a release candidate (suffix `-rcX`) the github 
release should be tagged as a pre-release so that it is clearly distinguished 
from stable releases in the Github UI