### PR TITLE
support: drop k8s 1.8 and support 1.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,7 +211,7 @@ spec:
     // See:
     //  az aks get-versions -l centralus
     //    --query 'sort(orchestrators[?orchestratorType==`Kubernetes`].orchestratorVersion)'
-    def aksKversions = ["1.8.14", "1.9.10"]
+    def aksKversions = ["1.9.11", "1.10.8"]
     for (x in aksKversions) {
         def kversion = x  // local bind required because closures
         def platform = "aks+k8s-" + kversion

--- a/README.md
+++ b/README.md
@@ -43,9 +43,8 @@ The following matrix shows which Kubernetes versions are supported in AKS and GK
 
 | Kubernetes version |  AKS  |  GKE  |
 |:------------------:|:-----:|:-----:|
-|        `1.8`       |  Yes  |  No   |
 |        `1.9`       |  Yes  |  Yes  |
-|        `1.10`      |  No   |  No   |
+|        `1.10`      |  Yes  |  Yes  |
 
 ### Components Version Support
 

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -22,7 +22,7 @@ In this section, you will deploy an Azure Kubernetes Service (AKS) cluster using
   export AZURE_RESOURCE_GROUP=my-kubeprod-group
   export AZURE_DNS_ZONE=example.com
   export AZURE_AKS_CLUSTER=my-aks-cluster
-  export AZURE_AKS_K8S_VERSION=1.9.10
+  export AZURE_AKS_K8S_VERSION=1.9.11
   ```
 
   - `AZURE_SUBSCRIPTION_ID` specifies the Azure subscription id. `az account list -o table` lists your Microsoft Azure subscriptions.
@@ -30,7 +30,7 @@ In this section, you will deploy an Azure Kubernetes Service (AKS) cluster using
   - `AZURE_RESOURCE_GROUP` specifies the name of the Azure resource group in which resources should be created.
   - `AZURE_DNS_ZONE` specifies the DNS suffix for the externally-visible websites and services deployed in the cluster.
   - `AZURE_AKS_CLUSTER` specifies the name of the AKS cluster.
-  - `AZURE_AKS_K8S_VERSION` specifies the version of Kubernetes to use for creating the cluster. The [BKPR Kubernetes version support matrix](../README.md#kubernetes-version-support-matrix-for-bkpr-10) lists the base Kubernetes versions supported by BKPR. `az aks get-versions --location ${AZURE_REGION}` lists the versions available in your region.
+  - `AZURE_AKS_K8S_VERSION` specifies the version of Kubernetes to use for creating the cluster. The [BKPR Kubernetes version support matrix](../README.md#kubernetes-version-support-matrix-for-bkpr-10) lists the base Kubernetes versions supported by BKPR. `az aks get-versions --location ${AZURE_REGION} -o table` lists the versions available in your region.
 
 * Set the default subscription account:
 

--- a/kubeprod/README.md
+++ b/kubeprod/README.md
@@ -16,7 +16,7 @@ AZURE_RESOURCE_GROUP_NAME="<your resource group name>"  # e.g. $USER
 AZURE_DNS_ZONE="<your delegated DNS zone>"              # e.g. "my.example.com"
 
 # First, create the AKS cluster (only if it does not exist yet) ...
-az aks create --resource-group "${AZURE_RESOURCE_GROUP_NAME}" --name "${AKS_CLUSTER_NAME}" --node-count 3 --node-vm-size Standard_DS2_v2 --ssh-key-value ~/.ssh/id_rsa.pub --kubernetes-version 1.9.6
+az aks create --resource-group "${AZURE_RESOURCE_GROUP_NAME}" --name "${AKS_CLUSTER_NAME}" --node-count 3 --node-vm-size Standard_DS2_v2 --ssh-key-value ~/.ssh/id_rsa.pub --kubernetes-version 1.9.11
 # ...and populate ~/.kube/config (required to use the Kubernetes API)
 az aks get-credentials --resource-group "${AZURE_RESOURCE_GROUP_NAME}" --name "${AKS_CLUSTER_NAME}"
 


### PR DESCRIPTION
Tested BKPR on K8S 1.10 on AKS as well as GKE and found no issues.
The K8S changelog does not indicate any changes that trigger changes in BKPR manifests.