### PR TITLE
[jjo] create bkpr-release.jsonnet to manifest all used images

### DIFF
--- a/manifests/components/bkpr-release.jsonnet
+++ b/manifests/components/bkpr-release.jsonnet
@@ -1,0 +1,66 @@
+{
+  // TODO(release): addon_resizer to use a single image
+  addon_resizer:: {
+    image:: "gcr.io/google_containers/addon-resizer:1.0",
+  },
+  addon_resizer__arch:: {
+    image:: "gcr.io/google_containers/addon-resizer-%(arch)s:2.1",
+  },
+  alpine:: {
+    image:: "alpine:3.6",
+  },
+  cert_manager:: {
+    image:: "bitnami/cert-manager:0.5.0-r36",
+  },
+  configmap_reloader:: {
+    image:: "jimmidyson/configmap-reload:v0.2.2",
+  },
+  default_backend:: {
+    image:: "gcr.io/google_containers/defaultbackend:1.4",
+  },
+  elasticsearch:: {
+    image:: "bitnami/elasticsearch:5.6.12-r2",
+  },
+  elasticsearch_exporter:: {
+    image:: "justwatch/elasticsearch_exporter:1.0.1",
+  },
+  edns:: {
+    image:: "bitnami/external-dns:0.5.4-r8",
+  },
+  etcd:: {
+    image:: "quay.io/coreos/etcd:v3.3.1",
+  },
+  fluentd_es:: {
+    image:: "bitnami/fluentd:1.2.2-r22",
+  },
+  gcp_broker:: {
+    image:: "gcr.io/gcp-services/catalog-oauth:latest",  // FIXME: release?
+  },
+  heapster__arch:: {
+    image:: "gcr.io/google_containers/heapster-%(arch)s:v1.5.2",
+  },
+  kibana:: {
+    image:: "bitnami/kibana:5.6.12-r15",
+  },
+  nginx_ingress_controller:: {
+    image:: "bitnami/nginx-ingress-controller:0.19.0-r8",
+  },
+  oauth2_proxy:: {
+    image:: "bitnami/oauth2-proxy:0.20180625.74543-debian-9-r6",
+  },
+  prometheus:: {
+    image:: "bitnami/prometheus:2.3.2-r41",
+  },
+  prometheus_node_exporter:: {
+    image:: "prom/node-exporter:v0.15.2",
+  },
+  prometheus_alertmanager:: {
+    image:: "bitnami/alertmanager:0.15.2-r36",
+  },
+  kube_state_metrics:: {
+    image:: "quay.io/coreos/kube-state-metrics:v1.1.0",
+  },
+  kubernetes_svc_cat:: {
+    image:: "quay.io/kubernetes-service-catalog/service-catalog:v0.1.9",
+  },
+}

--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local brpr_rel = import "bkpr-release.jsonnet";
 
 {
   p:: "",
@@ -105,7 +106,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             default: kube.Container("cert-manager") {
-              image: "bitnami/cert-manager:0.5.0-r36",
+              image: brpr_rel.cert_manager.image,
               args_+: {
                 "cluster-resource-namespace": "$(POD_NAMESPACE)",
                 "leader-election-namespace": "$(POD_NAMESPACE)",

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -19,8 +19,7 @@
 
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
-
-local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.12-r2";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
@@ -106,7 +105,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
           containers_+: {
             elasticsearch_logging: kube.Container("elasticsearch-logging") {
               local container = self,
-              image: ELASTICSEARCH_IMAGE,
+              image: bkpr_rel.elasticsearch.image,
               // This can massively vary depending on the logging volume
               securityContext: {
                 runAsUser: 1001,
@@ -164,7 +163,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
               },
             },
             prom_exporter: kube.Container("prom-exporter") {
-              image: "justwatch/elasticsearch_exporter:1.0.1",
+              image: bkpr_rel.elasticsearch_exporter.image,
               command: ["elasticsearch_exporter"],
               args_+: {
                 "es.uri": "http://localhost:%s/" % ELASTICSEARCH_HTTP_PORT,
@@ -183,7 +182,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
           },
           initContainers_+: {
             elasticsearch_logging_init: kube.Container("elasticsearch-logging-init") {
-              image: "alpine:3.6",
+              image: bkpr_rel.alpine.image,
               // TODO: investigate feasibility of switching to https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod
               // NOTE: copied verbatim from https://www.elastic.co/guide/en/elasticsearch/reference/5.6/vm-max-map-count.html
               command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"],

--- a/manifests/components/etcd.jsonnet
+++ b/manifests/components/etcd.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 {
   p:: "",
@@ -45,7 +46,7 @@ local kube = import "../lib/kube.libsonnet";
           terminationGracePeriodSeconds: 30,
           containers_+: {
             etcd: kube.Container("etcd") {
-              image: "quay.io/coreos/etcd:v3.3.1",
+              image: bkpr_rel.etcd.image,
               resources+: {
                 requests: {cpu: "100m", memory: "20Mi"},
                 limits: {cpu: "100m", memory: "30Mi"},

--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 {
   p:: "",
@@ -69,7 +70,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             edns: kube.Container("external-dns") {
-              image: "bitnami/external-dns:0.5.4-r8",
+              image: bkpr_rel.edns.image,
               args_+: {
                 sources_:: ["service", "ingress"],
                 "txt-owner-id": this.ownerId,

--- a/manifests/components/fluentd-es.jsonnet
+++ b/manifests/components/fluentd-es.jsonnet
@@ -20,8 +20,8 @@
 local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
-local FLUENTD_ES_IMAGE = "bitnami/fluentd:1.2.2-r22";
 local FLUENTD_ES_CONFIGD_PATH = "/opt/bitnami/fluentd/conf/config.d";
 local FLUENTD_ES_LOG_POS_PATH = "/var/log/fluentd-pos";
 local FLUENTD_ES_LOG_BUFFERS_PATH = "/var/log/fluentd-buffers";
@@ -75,7 +75,7 @@ local FLUENTD_ES_LOG_BUFFERS_PATH = "/var/log/fluentd-buffers";
         spec+: {
           containers_+: {
             fluentd_es: kube.Container("fluentd-es") {
-              image: FLUENTD_ES_IMAGE,
+              image: bkpr_rel.fluentd_es.image,
               securityContext: {
                 runAsUser: 0,  // required to be able to read system-wide logs.
               },

--- a/manifests/components/gcp-broker.jsonnet
+++ b/manifests/components/gcp-broker.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 // See https://github.com/GoogleCloudPlatform/k8s-service-catalog
 
@@ -64,7 +65,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             oauth: kube.Container("catalog-oauth") {
-              image: "gcr.io/gcp-services/catalog-oauth:latest",  // FIXME: release?
+              image: bkpr_rel.gcp_broker.image,
               args_+: {
                 n: "$(POD_NAMESPACE)",
                 v: 6,

--- a/manifests/components/heapster.jsonnet
+++ b/manifests/components/heapster.jsonnet
@@ -18,9 +18,9 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 local arch = "amd64";
-local version = "v1.5.2";
 
 {
   metadata:: {
@@ -84,7 +84,7 @@ local version = "v1.5.2";
           nodeSelector+: {"beta.kubernetes.io/arch": arch},
           containers_+: {
             default: kube.Container("heapster") {
-              image: "gcr.io/google_containers/heapster-%s:%s" % [arch, version],
+              image: bkpr_rel.heapster__arch.image % {arch: arch},
               command: ["/heapster"],
               args_+: {
                 source: "kubernetes.summary_api:''",
@@ -99,7 +99,7 @@ local version = "v1.5.2";
               },
             },
             nanny: kube.Container("heapster-nanny") {
-              image: "gcr.io/google_containers/addon-resizer-%s:2.1" % arch,
+              image: bkpr_rel.addon_resizer__arch.image % {arch: arch},
               command: ["/pod_nanny"],
               args_+: {
                 cpu: "80m",

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -21,7 +21,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local KIBANA_IMAGE = "bitnami/kibana:5.6.12-r15";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 local strip_trailing_slash(s) = (
   if std.endsWith(s, "/") then
@@ -49,7 +49,7 @@ local strip_trailing_slash(s) = (
         spec+: {
           containers_+: {
             kibana: kube.Container("kibana") {
-              image: KIBANA_IMAGE,
+              image: bkpr_rel.kibana.image,
               resources: {
                 requests: {
                   cpu: "10m",

--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -18,8 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-
-local NGNIX_INGRESS_IMAGE = "bitnami/nginx-ingress-controller:0.19.0-r8";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 {
   p:: "",
@@ -64,7 +63,7 @@ local NGNIX_INGRESS_IMAGE = "bitnami/nginx-ingress-controller:0.19.0-r8";
             terminationGracePeriodSeconds: 30,
             containers_+: {
               default: kube.Container("default-http-backend") {
-                image: "gcr.io/google_containers/defaultbackend:1.4",
+                image: bkpr_rel.default_backend.image,
                 readinessProbe: {
                   httpGet: {path: "/healthz", port: 8080, scheme: "HTTP"},
                   timeoutSeconds: 5,
@@ -196,7 +195,7 @@ local NGNIX_INGRESS_IMAGE = "bitnami/nginx-ingress-controller:0.19.0-r8";
           terminationGracePeriodSeconds: 60,
           containers_+: {
             default: kube.Container("nginx") {
-              image: NGNIX_INGRESS_IMAGE,
+              image: bkpr_rel.nginx_ingress_controller.image,
               securityContext: {
                 runAsUser: 1001,
                 capabilities: {

--- a/manifests/components/oauth2-proxy.jsonnet
+++ b/manifests/components/oauth2-proxy.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 {
   p:: "",
@@ -51,7 +52,7 @@ local kube = import "../lib/kube.libsonnet";
         spec+: {
           containers_+: {
             proxy: kube.Container("oauth2-proxy") {
-              image: "bitnami/oauth2-proxy:0.20180625.74543-debian-9-r6",
+              image: bkpr_rel.oauth2_proxy.image,
               args_+: {
                 "email-domain": "*",
                 "http-address": "0.0.0.0:4180",

--- a/manifests/components/svc-cat.jsonnet
+++ b/manifests/components/svc-cat.jsonnet
@@ -19,6 +19,7 @@
 
 local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
+local bkpr_rel = import "bkpr-release.jsonnet";
 
 // TODO: move into kube.libsonnet
 local APIService() = kube._Object("apiregistration.k8s.io/v1beta1", "APIService", "") {
@@ -129,7 +130,7 @@ local APIService() = kube._Object("apiregistration.k8s.io/v1beta1", "APIService"
             },
             containers_+: {
               apiserver: kube.Container("apiserver") {
-                image: kubecfg.resolveImage("quay.io/kubernetes-service-catalog/service-catalog:v0.1.9"),
+                image: kubecfg.resolveImage(bkpr_rel.kubernetes_svc_cat.image),
                 resources: {
                   requests: {cpu: "100m", memory: "20Mi"},
                   limits: {cpu: "100m", memory: "30Mi"},


### PR DESCRIPTION
Create `bkpr-release.jsonnet` to manifest all used images, mainly to:
- Have a clearer BKPR-wide picture of Bitnami/upstream images in use
- Have a more concise way to track BKPR release deltas
