### PR TITLE
GKE: Restrict Oauth authentication by domain suffix

### DIFF
--- a/kubeprod/pkg/aks/cmd.go
+++ b/kubeprod/pkg/aks/cmd.go
@@ -30,11 +30,12 @@ import (
 )
 
 const (
-	flagEmail     = "email"
-	flagDNSSuffix = "dns-zone"
-	flagSubID     = "subscription-id"
-	flagTenantID  = "tenant-id"
-	flagDNSResgrp = "dns-resource-group"
+	flagEmail       = "email"
+	flagDNSSuffix   = "dns-zone"
+	flagAuthzDomain = "authz-domain"
+	flagSubID       = "subscription-id"
+	flagTenantID    = "tenant-id"
+	flagDNSResgrp   = "dns-resource-group"
 )
 
 func defaultSubscription() *azcli.Subscription {
@@ -81,7 +82,7 @@ func init() {
 	}
 
 	aksCmd.PersistentFlags().String(flagEmail, os.Getenv("EMAIL"), "Contact email for cluster admin")
-
+	aksCmd.PersistentFlags().String(flagAuthzDomain, "*", "Restrict authorized users to this email domain.  Default '*' allows all users in Azure tenant.")
 	aksCmd.PersistentFlags().String(flagSubID, defSubID, "Azure subscription ID")
 	aksCmd.PersistentFlags().String(flagTenantID, defTenantID, "Azure tenant ID")
 	aksCmd.PersistentFlags().String(flagDNSSuffix, "", "External DNS zone for public endpoints")

--- a/kubeprod/pkg/aks/platform.go
+++ b/kubeprod/pkg/aks/platform.go
@@ -297,6 +297,14 @@ func (conf *AKSConfig) Generate(ctx context.Context) error {
 		conf.OauthProxy.ClientSecret = secret
 	}
 
+	if conf.OauthProxy.AuthzDomain == "" {
+		domain, err := flags.GetString(flagAuthzDomain)
+		if err != nil {
+			return err
+		}
+		conf.OauthProxy.AuthzDomain = domain
+	}
+
 	if conf.OauthProxy.AzureTenant == "" {
 		tenantID, err := flags.GetString(flagTenantID)
 		if err != nil {

--- a/kubeprod/pkg/aks/types.go
+++ b/kubeprod/pkg/aks/types.go
@@ -37,6 +37,7 @@ type OauthProxyConfig struct {
 	ClientID     string `json:"client_id"`
 	ClientSecret string `json:"client_secret"`
 	CookieSecret string `json:"cookie_secret"`
+	AuthzDomain  string `json:"authz_domain"`
 	AzureTenant  string `json:"azure_tenant"`
 }
 

--- a/kubeprod/pkg/gke/cmd.go
+++ b/kubeprod/pkg/gke/cmd.go
@@ -31,6 +31,7 @@ const (
 	flagEmail             = "email"
 	flagDNSSuffix         = "dns-zone"
 	flagProject           = "project"
+	flagAuthzDomain       = "authz-domain"
 	flagOauthClientId     = "oauth-client-id"
 	flagOauthClientSecret = "oauth-client-secret"
 	flagOauthGoogleGroups = "oauth-google-groups"
@@ -55,6 +56,8 @@ func init() {
 
 	gkeCmd.PersistentFlags().String(flagEmail, os.Getenv("EMAIL"), "Contact email for cluster admin")
 	gkeCmd.PersistentFlags().String(flagDNSSuffix, "", "External DNS zone for public endpoints")
+	gkeCmd.PersistentFlags().String(flagAuthzDomain, "", "Restrict authorized users to this Google email domain")
+	gkeCmd.MarkPersistentFlagRequired(flagAuthzDomain)
 	gkeCmd.PersistentFlags().String(flagProject, "", "GCP project to use for managed resources")
 	gkeCmd.PersistentFlags().String(flagOauthClientId, "", "Client ID to use for OAuth")
 	gkeCmd.PersistentFlags().String(flagOauthClientSecret, "", "Client secret to use for OAuth")

--- a/kubeprod/pkg/gke/platform.go
+++ b/kubeprod/pkg/gke/platform.go
@@ -316,6 +316,14 @@ func (conf *GKEConfig) Generate(ctx context.Context) error {
 		conf.OauthProxy.CookieSecret = secret
 	}
 
+	if conf.OauthProxy.AuthzDomain == "" {
+		domain, err := flags.GetString(flagAuthzDomain)
+		if err != nil {
+			return err
+		}
+		conf.OauthProxy.AuthzDomain = domain
+	}
+
 	if conf.OauthProxy.GoogleGroups == nil {
 		// Avoid json `null`
 		groups, err := flags.GetStringSlice(flagOauthGoogleGroups)

--- a/kubeprod/pkg/gke/types.go
+++ b/kubeprod/pkg/gke/types.go
@@ -36,6 +36,7 @@ type OauthProxyConfig struct {
 	ClientID                 string   `json:"client_id"`
 	ClientSecret             string   `json:"client_secret"`
 	CookieSecret             string   `json:"cookie_secret"`
+	AuthzDomain              string   `json:"authz_domain"`
 	GoogleGroups             []string `json:"google_groups"`
 	GoogleAdminEmail         string   `json:"google_admin_email"`
 	GoogleServiceAccountJson string   `json:"google_service_account_json"`

--- a/manifests/platforms/aks.jsonnet
+++ b/manifests/platforms/aks.jsonnet
@@ -96,6 +96,7 @@ local kibana = import "../components/kibana.jsonnet";
             containers_+: {
               proxy+: {
                 args_+: {
+                  "email-domain": $.config.oauthProxy.authz_domain,
                   provider: "azure",
                 },
                 env_+: {

--- a/manifests/platforms/gke.jsonnet
+++ b/manifests/platforms/gke.jsonnet
@@ -104,6 +104,7 @@ local kibana = import "../components/kibana.jsonnet";
             containers_+: {
               proxy+: {
                 args_+: {
+                  "email-domain": $.config.oauthProxy.authz_domain,
                   provider: "google",
                   "google-service-account-json": if $.config.oauthProxy.google_service_account_json != "" then "/google/credentials.json" else "",
                   "google-admin-email": $.config.oauthProxy.google_admin_email,

--- a/manifests/tests/aks.jsonnet
+++ b/manifests/tests/aks.jsonnet
@@ -34,6 +34,7 @@
       client_id: "myclientid",
       client_secret: "mysecret",
       cookie_secret: "cookiesecret",
+      authz_domain: "test.invalid",
       azure_tenant: "mytenant",
     },
   },

--- a/manifests/tests/gke.jsonnet
+++ b/manifests/tests/gke.jsonnet
@@ -31,6 +31,7 @@
       client_id: "myclientid",
       client_secret: "mysecret",
       cookie_secret: "cookiesecret",
+      authz_domain: "test.invalid",
       google_groups: [],
       google_admin_email: "admin@example.com",
       google_service_account_json: "<fake google credentials json contents>",


### PR DESCRIPTION
With Google-based Oauth, we need to additionally restrict the user in
some way - we don't want to allow just _any_ Google account to access
the prometheus/kibana consoles.

This change adds a *required* flag to specify a Google email domain,
and oauth2 proxy will only allow Google users from this domain.

NB: This effectively restricts kubeprod to only supporting GSuite
accounts (@gmail.com is not useful), which is conceptually similar to
the AKS setup which allows only members from a particular Azure
tenant.  Allowing a whitelist of specific (non-GSuite) Gmail accounts
instead is probably desirable, but postponed for a future change.