### PR TITLE
"authz_domain" is an optional field in the JSON configuration file.

### DIFF
--- a/manifests/platforms/aks.jsonnet
+++ b/manifests/platforms/aks.jsonnet
@@ -99,7 +99,7 @@ local kibana = import "../components/kibana.jsonnet";
             containers_+: {
               proxy+: {
                 args_+: {
-                  "email-domain": $.config.oauthProxy.authz_domain,
+                  "email-domain": if std.objectHas($.config.oauthProxy, 'authz_domain') then $.config.oauthProxy.authz_domain else '*',
                   provider: "azure",
                 },
                 env_+: {

--- a/manifests/platforms/gke.jsonnet
+++ b/manifests/platforms/gke.jsonnet
@@ -107,7 +107,7 @@ local kibana = import "../components/kibana.jsonnet";
             containers_+: {
               proxy+: {
                 args_+: {
-                  "email-domain": $.config.oauthProxy.authz_domain,
+                  "email-domain": if std.objectHas($.config.oauthProxy, 'authz_domain') then $.config.oauthProxy.authz_domain else '*',
                   provider: "google",
                   "google-service-account-json": if $.config.oauthProxy.google_service_account_json != "" then "/google/credentials.json" else "",
                   "google-admin-email": $.config.oauthProxy.google_admin_email,


### PR DESCRIPTION
PR #177 introduced the "authz_domain" field in the JSON configuration file which means that BKPR deployments prior to PR #177 won't have it listed among the attributes. Hence this PR provides a default value of "*" when it is not defined.