### PR TITLE
Get kubeprod latest release programatically in quickstart guides

### DIFF
--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -85,10 +85,8 @@ BKPR releases are available for 64-bit versions of Linux, macOS and Windows plat
 For convenience lets define a environment variable with the BKPR version:
 
 ```bash
-export BKPR_VERSION=vX.Y.Z
+export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 ```
-
-_Update `vX.Y.Z` with the actual BKPR version. Ideally this would be the most recent release._
 
 On Linux:
 

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -85,7 +85,7 @@ BKPR releases are available for 64-bit versions of Linux, macOS and Windows plat
 For convenience lets define a environment variable with the BKPR version:
 
 ```bash
-export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | jq -r '.tag_name')
 ```
 
 On Linux:

--- a/docs/quickstart-gke.md
+++ b/docs/quickstart-gke.md
@@ -113,7 +113,7 @@ BKPR releases are available for 64-bit versions of Linux, macOS and Windows plat
 For convenience lets define a environment variable with the BKPR version:
 
 ```bash
-export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
+export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | jq -r '.tag_name')
 ```
 
 On Linux:

--- a/docs/quickstart-gke.md
+++ b/docs/quickstart-gke.md
@@ -113,10 +113,8 @@ BKPR releases are available for 64-bit versions of Linux, macOS and Windows plat
 For convenience lets define a environment variable with the BKPR version:
 
 ```bash
-export BKPR_VERSION=vX.Y.Z
+export BKPR_VERSION=$(curl --silent "https://api.github.com/repos/bitnami/kube-prod-runtime/releases/latest" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
 ```
-
-_Update `vX.Y.Z` with the actual BKPR version. Ideally this would be the most recent release._
 
 On Linux:
 


### PR DESCRIPTION
This will default to the latest *release* available of kubeprod. By the moment it will be set to:

```
~/projects/kube-prod-runtime$ echo $BKPR_VERSION
v0.3.1
```

Let me know what you think :)
