### PR TITLE
Update Prometheus to 2.4.3

### DIFF
--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -26,7 +26,7 @@ local path_join(prefix, suffix) = (
   else prefix + "/" + suffix
 );
 
-local PROMETHEUS_IMAGE = "bitnami/prometheus:2.3.2-r41";
+local PROMETHEUS_IMAGE = "bitnami/prometheus:2.4.3-r31";
 local PROMETHEUS_CONF_MOUNTPOINT = "/opt/bitnami/prometheus/conf/custom";
 local PROMETHEUS_PORT = 9090;
 


### PR DESCRIPTION
This PR updates Prometheus to the latest available version deployed by Bitnami.
Based on the [Prometheus changelog](https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#240--2018-09-11) in the `2.4.0` version the WAL implementation was re-written, so the storage is not forward compatible.
Prometheus 2.3 storage will work on 2.4 but not vice-versa.

Tested this upgrade manually in Kubeprod changing the statefulset to point to the latest version of Prometheus in my dev environment and didn't face any issue, the update was successfully.


None of the rest of changes of newer versions of Prometheus affect to the current configuration we have in kubeprod. 

Reference: https://github.com/prometheus/prometheus/blob/master/CHANGELOG.md#240--2018-09-11