### PR TITLE
Change `--manifests` default to point to versioned github URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ def runIntegrationTest(String description, String kubeprodArgs, String ginkgoArg
 
                 sh "kubectl --namespace kube-system get po,deploy,svc,ing"
 
-                sh "./bin/kubeprod -v=1 install --manifests=manifests --config=kubeprod-autogen.json ${kubeprodArgs}"
+                sh "./bin/kubeprod -v=1 install --config=kubeprod-autogen.json ${kubeprodArgs}"
 
                 dnsSetup()
 
@@ -192,7 +192,7 @@ spec:
                 withGo() {
                     withEnv(["PATH+JQ=${tool 'jq'}"]) {
                         withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: '')]) {
-                            sh "make release-notes VERSION=${env.TAG_NAME}"
+                            sh "make release-notes VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
                         }
                         stash includes: 'Release_Notes.md', name: 'release-notes'
                     }
@@ -490,10 +490,10 @@ gcloud container clusters create ${clusterName} \
                             unstash 'src'
                             unstash 'release-notes'
 
-                            sh "make dist VERSION=${env.TAG_NAME}"
+                            sh "make dist VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
 
                             withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: '')]) {
-                                sh "make publish VERSION=${env.TAG_NAME}"
+                                sh "make publish VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
                             }
                         }
                     }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-VERSION ?= dev-$(shell date +%FT%T%z)
+export VERSION ?= $(shell git describe --tags --dirty)
+export GIT_TAG ?= $(shell git rev-parse HEAD)
 
 GITHUB_USER ?= bitnami
 GITHUB_REPO ?= kube-prod-runtime
@@ -18,15 +19,15 @@ endif
 	@set -e ; \
 	PREV_VERSION=$$(git -c 'versionsort.suffix=-' tag --list  --sort=-v:refname | grep -m2 "^v[0-9]*\.[0-9]*\.[0-9]*$$" | tail -n1) ; \
 	echo -n > jenkins/Changes.lst ; \
-	for pr in $$(git log $${PREV_VERSION}..$(VERSION) --pretty=format:"%s" | grep '(#[0-9]*)$$' | cut -d"#" -f2 | cut -d' ' -f1); do \
+	for pr in $$(git log $${PREV_VERSION}..$(GIT_TAG) --pretty=format:"%s" | grep '(#[0-9]*)$$' | cut -d"#" -f2 | cut -d' ' -f1); do \
 		wget -q --header "Authorization: token $${GITHUB_TOKEN}" "https://api.github.com/repos/$(GITHUB_USER)/$(GITHUB_REPO)/pulls/$${pr}" -O - | \
 			jq -r '[.number,.title,.user.login] | "- \(.[1]) (#\(.[0])) - @\(.[2])"' >> jenkins/Changes.lst ; \
 	done ; \
 	if [ $$(cat jenkins/Changes.lst | wc -l) -eq 0 ]; then \
-		git log $${PREV_VERSION}..$(VERSION) --pretty=format:"- %s" >> jenkins/Changes.lst ; \
+		git log $${PREV_VERSION}..$(GIT_TAG) --pretty=format:"- %s" >> jenkins/Changes.lst ; \
 		echo >> jenkins/Changes.lst ; \
 	fi ; \
-	git cat-file -p $(VERSION) | sed '/-----BEGIN PGP SIGNATURE-----/,/-----END PGP SIGNATURE-----/d' | tail -n +6 > Release_Notes.md ; \
+	git cat-file -p $(GIT_TAG) | sed '/-----BEGIN PGP SIGNATURE-----/,/-----END PGP SIGNATURE-----/d' | tail -n +6 > Release_Notes.md ; \
 	cat jenkins/Release_Notes.md.tmpl >> Release_Notes.md ; \
 	cat jenkins/Changes.lst >> Release_Notes.md ; \
 	rm -f jenkins/Changes.lst
@@ -34,16 +35,16 @@ endif
 release-notes: Release_Notes.md
 
 dist:
-	$(MAKE) -C kubeprod $@ VERSION=$(VERSION)
+	$(MAKE) -C kubeprod $@
 
 publish: github-release release-notes
 ifndef GITHUB_TOKEN
 	$(error You must specify the GITHUB_TOKEN)
 endif
-	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' || :
+	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' || :
 	@set -e ; \
-	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' -n 'BKPR $(VERSION)' -d -
-	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' --name "$$(basename $${f})" --file "$${f}" ; done
+	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' -n 'BKPR $(VERSION)' -d -
+	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' --name "$$(basename $${f})" --file "$${f}" ; done
 
 clean:
 	rm -f Release_Notes.md

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -1,4 +1,5 @@
-VERSION ?= dev-$(shell date +%FT%T%z)
+VERSION ?= $(shell git describe --tags --dirty)
+GIT_TAG ?= $(shell git rev-parse HEAD)
 TARGETS ?= darwin/amd64 linux/amd64 windows/amd64
 MANIFEST_DIST_DIRS = lib components platforms
 
@@ -6,7 +7,7 @@ PACKAGE = kubeprod
 
 GO = go
 GOFLAGS =
-GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION)'
+GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION) -X main.gitTag=$(GIT_TAG)'
 GORELEASEFLAGS = $(GOBUILDFLAGS) -tags netgo -installsuffix netgo
 GOTESTFLAGS = $(GOFLAGS) -race
 GOFMT = gofmt

--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -31,8 +31,8 @@ import (
 )
 
 const (
-	FlagManifests       = "manifests"
-	DefaultManifestBase = "https://github.com/bitnami/kube-prod-runtime/manifests/"
+	FlagManifests          = "manifests"
+	defaultManifestBaseFmt = "https://github.com/bitnami/kube-prod-runtime/raw/%s/manifests/"
 
 	FlagPlatformConfig = "config"
 )
@@ -43,10 +43,14 @@ var InstallCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 }
 
+func DefaultManifestBase() string {
+	return fmt.Sprintf(defaultManifestBaseFmt, GitTag)
+}
+
 func init() {
 	RootCmd.AddCommand(InstallCmd)
 
-	InstallCmd.PersistentFlags().String(FlagManifests, DefaultManifestBase, "Base URL below which to find platform manifests")
+	InstallCmd.PersistentFlags().String(FlagManifests, DefaultManifestBase(), "Base URL below which to find platform manifests")
 	InstallCmd.PersistentFlags().String(FlagPlatformConfig, prodruntime.DefaultPlatformConfig, "Path for generated platform config file")
 }
 

--- a/kubeprod/cmd/root.go
+++ b/kubeprod/cmd/root.go
@@ -60,6 +60,18 @@ func init() {
 	RootCmd.PersistentFlags().AddGoFlagSet(goflag.CommandLine)
 }
 
+// Called at top of main() to re-set any flags that may have changed
+// default value.  Hack to force this to occur after init().
+func UpdateFlagDefaults() {
+	set := func(cmd *cobra.Command, flag, value string) {
+		f := cmd.Flag(flag)
+		f.DefValue = value
+		f.Value.Set(value)
+	}
+
+	set(InstallCmd, FlagManifests, DefaultManifestBase())
+}
+
 var RootCmd = &cobra.Command{
 	Use:           "kubeprod",
 	Short:         "Install the Bitnami Kubernetes Production Runtime",

--- a/kubeprod/cmd/version.go
+++ b/kubeprod/cmd/version.go
@@ -29,7 +29,9 @@ import (
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 )
 
+// NB: These are overridden by main()
 var Version = "(dev build)"
+var GitTag = "master"
 
 const (
 	ReleaseNamespace = "kubeprod"

--- a/kubeprod/main.go
+++ b/kubeprod/main.go
@@ -35,10 +35,18 @@ import (
 	_ "github.com/bitnami/kube-prod-runtime/kubeprod/pkg/gke"
 )
 
+// Overridden at link time by Makefile.
 var version = "(dev build)"
+var gitTag = "master"
+
+func init() {
+	cmd.Version = version
+	cmd.GitTag = gitTag
+}
 
 func main() {
-	cmd.Version = version
+	// Update flag defaults now that all init() have completed
+	cmd.UpdateFlagDefaults()
 
 	if err := cmd.RootCmd.Execute(); err != nil {
 		// PersistentPreRunE may not have been run for early

--- a/kubeprod/pkg/installer/install.go
+++ b/kubeprod/pkg/installer/install.go
@@ -110,19 +110,13 @@ func (c InstallCmd) Run(out io.Writer) error {
 		return err
 	}
 
-	searchPaths := []string{
-		"internal:///",
-	}
-	searchUrls := make([]*url.URL, len(searchPaths))
-	for i, p := range searchPaths {
-		searchUrls[i], err = c.ManifestBase.Parse(p)
-		if err != nil {
-			return fmt.Errorf("unable to make URL from %q (relative to %q): %v", p, c.ManifestBase, err)
-		}
+	manifestURL, err := c.ManifestBase.Parse(fmt.Sprintf("platforms/%s.jsonnet", c.Platform))
+	if err != nil {
+		return fmt.Errorf("unable to construct manifest URL: %v", err)
 	}
 
-	log.Info("Generating root manifest for platform ", c.Platform)
-	if err := prodruntime.WriteRootManifest(c.ManifestBase.Path, c.Platform); err != nil {
+	log.Infof("Using manifests from %s", manifestURL)
+	if err := prodruntime.WriteRootManifest(manifestURL); err != nil {
 		return err
 	}
 

--- a/kubeprod/pkg/prodruntime/manifest.go
+++ b/kubeprod/pkg/prodruntime/manifest.go
@@ -22,6 +22,7 @@ package prodruntime
 import (
 	"bufio"
 	"fmt"
+	"net/url"
 	"os"
 	"text/template"
 
@@ -29,11 +30,12 @@ import (
 )
 
 const (
-	clusterTemplate = `# Cluster-specific configuration
-(import "{{.ManifestsPath}}platforms/{{.Platform}}.jsonnet") {
+	clusterTemplate = `// Cluster-specific configuration
+(import "{{.ManifestsURL}}") {
 	config:: import "{{.ConfigFilePath}}",
 	// Place your overrides here
-}`
+}
+`
 
 	// RootManifest specifies the filename of the root (cluster) manifest
 	RootManifest          = "kubeprod-manifest.jsonnet"
@@ -43,12 +45,11 @@ const (
 // WriteRootManifest executes the template from the `clusterTemplate`
 // variable and writes the result as the root (cluster) manifest in
 // the current directory named after the value of `RootManifest`.
-func WriteRootManifest(manifestsBase string, platform string) error {
+func WriteRootManifest(manifestsURL *url.URL) error {
 	// If the output file already exists do not overwrite it.
 	v := map[string]string{
 		"ConfigFilePath": DefaultPlatformConfig,
-		"ManifestsPath":  manifestsBase,
-		"Platform":       platform,
+		"ManifestsURL":   manifestsURL.String(),
 	}
 	f, err := os.OpenFile(RootManifest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0777)
 	if err != nil {


### PR DESCRIPTION
Make the `kubeprod install --manifests` flag default to a URL derived
from the git tag/sha used at build-time.  This should "just work" in
most situations.

Fixes #212 