### PR TITLE
Allow bypassing actual deployment of BKPR by the `install` command.

### DIFF
--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -34,7 +34,6 @@ const (
 	FlagManifests          = "manifests"
 	defaultManifestBaseFmt = "https://github.com/bitnami/kube-prod-runtime/raw/%s/manifests/"
 	FlagOnlyGenerate       = "only-generate"
-	FlagOnlyGenerateShort  = "g"
 	FlagPlatformConfig     = "config"
 )
 
@@ -53,7 +52,7 @@ func init() {
 
 	InstallCmd.PersistentFlags().String(FlagManifests, DefaultManifestBase(), "Base URL below which to find platform manifests")
 	InstallCmd.PersistentFlags().String(FlagPlatformConfig, prodruntime.DefaultPlatformConfig, "Path for generated platform config file")
-	InstallCmd.PersistentFlags().BoolP(FlagOnlyGenerate, FlagOnlyGenerateShort, false, "Whether to just generate the root manifest and configuration files")
+	InstallCmd.PersistentFlags().Bool(FlagOnlyGenerate, false, "Stop before pushing configuration to the cluster")
 }
 
 // Common initialisation for platform install subcommands

--- a/kubeprod/pkg/installer/install.go
+++ b/kubeprod/pkg/installer/install.go
@@ -120,11 +120,8 @@ func (c InstallCmd) Run(out io.Writer) error {
 		return err
 	}
 
-	// TODO(felipe): Conditionalize this with a command-line flag so this
-	// step is optional
 	if c.OnlyGenerate {
-		fmt.Println("Kubernetes cluster is ready for deployment.")
-		fmt.Println("run: `kubeprod install` without the --only-generate command-line flag.")
+		fmt.Println("Skipping deployment because --only-generate was provided.")
 	} else {
 		log.Info("Deploying Bitnami Kubernetes Production Runtime for platform ", c.Platform)
 		if err := c.Update(out); err != nil {


### PR DESCRIPTION
Implements a command-line flag named `--only-generate` in the `install` command that allows skipping the part that deploys BKPR to the Kubernetes cluster. The idea is to configure the underlying platform (e.g. DNS zone, security principals, etc.) and then generate the root manifest and JSON configuration files. Then, the user can add overrides and customise the root manifest, then run `kubeprod` again without the `--only-generate` command-line flag to get BKPR deployed.