### PR TITLE
Allow overriding the pathname of JSON configuration file

### DIFF
--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -26,13 +26,13 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/bitnami/kube-prod-runtime/kubeprod/pkg/installer"
-	"github.com/bitnami/kube-prod-runtime/kubeprod/pkg/prodruntime"
 	"github.com/bitnami/kube-prod-runtime/kubeprod/tools"
 )
 
 const (
 	FlagManifests          = "manifests"
 	defaultManifestBaseFmt = "https://github.com/bitnami/kube-prod-runtime/raw/%s/manifests/"
+	defaultPlatformConfig  = "kubeprod-autogen.json"
 	FlagOnlyGenerate       = "only-generate"
 	FlagPlatformConfig     = "config"
 )
@@ -51,7 +51,7 @@ func init() {
 	RootCmd.AddCommand(InstallCmd)
 
 	InstallCmd.PersistentFlags().String(FlagManifests, DefaultManifestBase(), "Base URL below which to find platform manifests")
-	InstallCmd.PersistentFlags().String(FlagPlatformConfig, prodruntime.DefaultPlatformConfig, "Path for generated platform config file")
+	InstallCmd.PersistentFlags().String(FlagPlatformConfig, defaultPlatformConfig, "Path for generated platform config file")
 	InstallCmd.PersistentFlags().Bool(FlagOnlyGenerate, false, "Stop before pushing configuration to the cluster")
 }
 

--- a/kubeprod/pkg/installer/install.go
+++ b/kubeprod/pkg/installer/install.go
@@ -116,7 +116,7 @@ func (c InstallCmd) Run(out io.Writer) error {
 	}
 
 	log.Infof("Using manifests from %s", manifestURL)
-	if err := prodruntime.WriteRootManifest(manifestURL); err != nil {
+	if err := prodruntime.WriteRootManifest(manifestURL, c.PlatformConfigPath); err != nil {
 		return err
 	}
 

--- a/kubeprod/pkg/prodruntime/manifest.go
+++ b/kubeprod/pkg/prodruntime/manifest.go
@@ -38,17 +38,16 @@ const (
 `
 
 	// RootManifest specifies the filename of the root (cluster) manifest
-	RootManifest          = "kubeprod-manifest.jsonnet"
-	DefaultPlatformConfig = "kubeprod-autogen.json"
+	RootManifest = "kubeprod-manifest.jsonnet"
 )
 
 // WriteRootManifest executes the template from the `clusterTemplate`
 // variable and writes the result as the root (cluster) manifest in
 // the current directory named after the value of `RootManifest`.
-func WriteRootManifest(manifestsURL *url.URL) error {
+func WriteRootManifest(manifestsURL *url.URL, platformConfigPath string) error {
 	// If the output file already exists do not overwrite it.
 	v := map[string]string{
-		"ConfigFilePath": DefaultPlatformConfig,
+		"ConfigFilePath": platformConfigPath,
 		"ManifestsURL":   manifestsURL.String(),
 	}
 	f, err := os.OpenFile(RootManifest, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0777)


### PR DESCRIPTION
Actually generate a JSON configuration file named according to the value of the --config command-line flag.