### PR TITLE
Upload release manifests to S3 bucket

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -492,7 +492,7 @@ gcloud container clusters create ${clusterName} \
 
                             sh "make dist VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
 
-                            withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: '')]) {
+                            withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: ''),]) {
                                 sh "make publish VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -492,7 +492,15 @@ gcloud container clusters create ${clusterName} \
 
                             sh "make dist VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
 
-                            withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: ''),]) {
+                            withCredentials([
+                                usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: ''),
+                                [
+                                $class: 'AmazonWebServicesCredentialsBinding',
+                                credentialsId: 'jenkins-bkpr-releases',
+                                accessKeyVariable: 'AWS_ACCESS_KEY_ID',
+                                secretKeyVariable: 'AWS_SECRET_ACCESS_KEY',
+                                ]
+                            ]) {
                                 sh "make publish VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
                             }
                         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -102,7 +102,7 @@ def runIntegrationTest(String description, String kubeprodArgs, String ginkgoArg
 
                 sh "kubectl --namespace kube-system get po,deploy,svc,ing"
 
-                sh "./bin/kubeprod -v=1 install --config=kubeprod-autogen.json ${kubeprodArgs}"
+                sh "./bin/kubeprod -v=1 install --manifests=manifests --config=kubeprod-autogen.json ${kubeprodArgs}"
 
                 dnsSetup()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,7 @@ spec:
                 withGo() {
                     withEnv(["PATH+JQ=${tool 'jq'}"]) {
                         withCredentials([usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: '')]) {
-                            sh "make release-notes VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
+                            sh "make release-notes VERSION=${TAG_NAME}"
                         }
                         stash includes: 'Release_Notes.md', name: 'release-notes'
                     }
@@ -490,7 +490,7 @@ gcloud container clusters create ${clusterName} \
                             unstash 'src'
                             unstash 'release-notes'
 
-                            sh "make dist VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
+                            sh "make dist VERSION=${TAG_NAME}"
 
                             withCredentials([
                                 usernamePassword(credentialsId: 'github-bitnami-bot', passwordVariable: 'GITHUB_TOKEN', usernameVariable: ''),
@@ -501,7 +501,7 @@ gcloud container clusters create ${clusterName} \
                                 secretKeyVariable: 'AWS_SECRET_ACCESS_KEY',
                                 ]
                             ]) {
-                                sh "make publish VERSION=${TAG_NAME} GIT_TAG=${TAG_NAME}"
+                                sh "make publish VERSION=${TAG_NAME}"
                             }
                         }
                     }

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ export GIT_TAG ?= $(shell git rev-parse HEAD)
 GITHUB_USER ?= bitnami
 GITHUB_REPO ?= kube-prod-runtime
 GITHUB_TOKEN ?=
+export GITHUB_TOKEN
 
 GO = go
 
@@ -37,7 +38,7 @@ release-notes: Release_Notes.md
 dist:
 	$(MAKE) -C kubeprod $@
 
-publish: github-release release-notes
+publish-to-github: github-release release-notes
 ifndef GITHUB_TOKEN
 	$(error You must specify the GITHUB_TOKEN)
 endif
@@ -45,6 +46,8 @@ endif
 	@set -e ; \
 	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' -n 'BKPR $(VERSION)' -d -
 	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' --name "$$(basename $${f})" --file "$${f}" ; done
+
+publish: publish-to-github
 
 clean:
 	rm -f Release_Notes.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export VERSION ?= $(shell git describe --tags --dirty)
+VERSION ?= $(shell git rev-parse --short HEAD)
 export GIT_TAG ?= $(shell git rev-parse HEAD)
 
 GITHUB_USER ?= bitnami

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 VERSION ?= $(shell git rev-parse --short HEAD)
-export GIT_TAG ?= $(shell git rev-parse HEAD)
 
 GITHUB_USER ?= bitnami
 GITHUB_REPO ?= kube-prod-runtime
@@ -25,15 +24,15 @@ endif
 	@set -e ; \
 	PREV_VERSION=$$(git -c 'versionsort.suffix=-' tag --list  --sort=-v:refname | grep -m2 "^v[0-9]*\.[0-9]*\.[0-9]*$$" | tail -n1) ; \
 	echo -n > jenkins/Changes.lst ; \
-	for pr in $$(git log $${PREV_VERSION}..$(GIT_TAG) --pretty=format:"%s" | grep '(#[0-9]*)$$' | cut -d"#" -f2 | cut -d' ' -f1); do \
+	for pr in $$(git log $${PREV_VERSION}..$(VERSION) --pretty=format:"%s" | grep '(#[0-9]*)$$' | cut -d"#" -f2 | cut -d')' -f1); do \
 		wget -q --header "Authorization: token $${GITHUB_TOKEN}" "https://api.github.com/repos/$(GITHUB_USER)/$(GITHUB_REPO)/pulls/$${pr}" -O - | \
 			jq -r '[.number,.title,.user.login] | "- \(.[1]) (#\(.[0])) - @\(.[2])"' >> jenkins/Changes.lst ; \
 	done ; \
 	if [ $$(cat jenkins/Changes.lst | wc -l) -eq 0 ]; then \
-		git log $${PREV_VERSION}..$(GIT_TAG) --pretty=format:"- %s" >> jenkins/Changes.lst ; \
+		git log $${PREV_VERSION}..$(VERSION) --pretty=format:"- %s" >> jenkins/Changes.lst ; \
 		echo >> jenkins/Changes.lst ; \
 	fi ; \
-	git cat-file -p $(GIT_TAG) | sed '/-----BEGIN PGP SIGNATURE-----/,/-----END PGP SIGNATURE-----/d' | tail -n +6 > Release_Notes.md ; \
+	git cat-file -p $(VERSION) | sed '/-----BEGIN PGP SIGNATURE-----/,/-----END PGP SIGNATURE-----/d' | tail -n +6 > Release_Notes.md ; \
 	cat jenkins/Release_Notes.md.tmpl >> Release_Notes.md ; \
 	cat jenkins/Changes.lst >> Release_Notes.md ; \
 	rm -f jenkins/Changes.lst
@@ -47,10 +46,10 @@ publish-to-github: github-release release-notes
 ifndef GITHUB_TOKEN
 	$(error You must specify the GITHUB_TOKEN)
 endif
-	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' || :
+	github-release delete --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' || :
 	@set -e ; \
-	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' -n 'BKPR $(VERSION)' -d -
-	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(GIT_TAG)' --name "$$(basename $${f})" --file "$${f}" ; done
+	PRE_RELEASE=$${VERSION##*-rc} ; cat Release_Notes.md | github-release release $${PRE_RELEASE:+--pre-release} --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' -n 'BKPR $(VERSION)' -d -
+	for f in $$(ls kubeprod/_dist/*.gz kubeprod/_dist/*.zip) ; do github-release upload --user $(GITHUB_USER) --repo $(GITHUB_REPO) --tag '$(VERSION)' --name "$$(basename $${f})" --file "$${f}" ; done
 
 publish-to-s3: awless
 ifndef AWS_ACCESS_KEY_ID

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -1,5 +1,5 @@
 VERSION ?= $(shell git rev-parse --short HEAD)
-RELEASES_BASE_URL ?= https://releases.kubeprod.io
+RELEASES_BASE_URL ?=
 TARGETS ?= darwin/amd64 linux/amd64 windows/amd64
 MANIFEST_DIST_DIRS = lib components platforms
 

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -1,4 +1,4 @@
-VERSION ?= $(shell git describe --tags --dirty)
+VERSION ?= $(shell git rev-parse --short HEAD)
 GIT_TAG ?= $(shell git rev-parse HEAD)
 TARGETS ?= darwin/amd64 linux/amd64 windows/amd64
 MANIFEST_DIST_DIRS = lib components platforms

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -1,4 +1,5 @@
 VERSION ?= $(shell git rev-parse --short HEAD)
+RELEASES_BASE_URL ?= https://releases.kubeprod.io
 TARGETS ?= darwin/amd64 linux/amd64 windows/amd64
 MANIFEST_DIST_DIRS = lib components platforms
 
@@ -6,7 +7,7 @@ PACKAGE = kubeprod
 
 GO = go
 GOFLAGS =
-GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION)'
+GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION) -X main.releasesBaseUrl=$(RELEASES_BASE_URL)'
 GORELEASEFLAGS = $(GOBUILDFLAGS) -tags netgo -installsuffix netgo
 GOTESTFLAGS = $(GOFLAGS) -race
 GOFMT = gofmt

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -36,16 +36,16 @@ release: clean
 
 manifests: release
 	@set -e ; \
+	mkdir -p _dist/manifests/ ; \
+	echo $(VERSION) > _dist/manifests/VERSION ; \
+	for d in $(MANIFEST_DIST_DIRS); do \
+		cp -a ../manifests/$${d} _dist/manifests/ ; \
+	done ; \
 	for platform in $(TARGETS); do \
 		GOOS=$${platform%/*} ; \
 		GOARCH=$${platform#*/} ; \
 		ARTIFACTS_DIR=_dist/$${GOOS}-$${GOARCH}/bkpr-$(VERSION) ; \
-		for d in $(MANIFEST_DIST_DIRS); do \
-			mkdir -p $${ARTIFACTS_DIR}/manifests/ ; \
-			echo "cp -a ../manifests/$${d} $${ARTIFACTS_DIR}/manifests/" ; \
-			cp -a ../manifests/$${d} $${ARTIFACTS_DIR}/manifests/ ; \
-			echo $(VERSION) > $${ARTIFACTS_DIR}/manifests/VERSION ; \
-		done ; \
+		cp -a _dist/manifests $${ARTIFACTS_DIR}/ ; \
 	done
 
 dist: archiver release manifests

--- a/kubeprod/Makefile
+++ b/kubeprod/Makefile
@@ -1,5 +1,4 @@
 VERSION ?= $(shell git rev-parse --short HEAD)
-GIT_TAG ?= $(shell git rev-parse HEAD)
 TARGETS ?= darwin/amd64 linux/amd64 windows/amd64
 MANIFEST_DIST_DIRS = lib components platforms
 
@@ -7,7 +6,7 @@ PACKAGE = kubeprod
 
 GO = go
 GOFLAGS =
-GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION) -X main.gitTag=$(GIT_TAG)'
+GOBUILDFLAGS = $(GOFLAGS) -ldflags='-X main.version=$(VERSION)'
 GORELEASEFLAGS = $(GOBUILDFLAGS) -tags netgo -installsuffix netgo
 GOTESTFLAGS = $(GOFLAGS) -race
 GOFMT = gofmt

--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	FlagManifests          = "manifests"
-	defaultManifestBaseFmt = "https://github.com/bitnami/kube-prod-runtime/raw/%s/manifests/"
+	defaultManifestBaseFmt = "http://jenkins-bkpr-releases.s3-website-us-east-1.amazonaws.com/files/%s/manifests/"
 	FlagOnlyGenerate       = "only-generate"
 	FlagPlatformConfig     = "config"
 )

--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -31,13 +31,14 @@ import (
 	"github.com/bitnami/kube-prod-runtime/kubeprod/tools"
 )
 
+var ReleasesBaseUrl = "https://releases.kubeprod.io"
+
 const (
 	FlagManifests      = "manifests"
 	FlagOnlyGenerate   = "only-generate"
 	FlagPlatformConfig = "config"
 
-	defaultManifestBaseFmt = "http://jenkins-bkpr-releases.s3-website-us-east-1.amazonaws.com/files/%s/manifests/"
-	releaseSignature       = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-rc[0-9]+)?$"
+	releaseSignature = "^v[0-9]+\\.[0-9]+\\.[0-9]+(-rc[0-9]+)?$"
 )
 
 var InstallCmd = &cobra.Command{
@@ -54,7 +55,10 @@ func IsRelease() bool {
 func DefaultManifestBase() string {
 	manifestBase := ""
 	if IsRelease() {
-		manifestBase = fmt.Sprintf(defaultManifestBaseFmt, Version)
+		if !strings.HasSuffix(ReleasesBaseUrl, "/") {
+			ReleasesBaseUrl = ReleasesBaseUrl + "/"
+		}
+		manifestBase = fmt.Sprintf("%sfiles/%s/manifests", ReleasesBaseUrl, Version)
 	}
 	return manifestBase
 }

--- a/kubeprod/cmd/root.go
+++ b/kubeprod/cmd/root.go
@@ -68,8 +68,11 @@ func UpdateFlagDefaults() {
 		f.DefValue = value
 		f.Value.Set(value)
 	}
-
 	set(InstallCmd, FlagManifests, DefaultManifestBase())
+
+	if !IsRelease() {
+		InstallCmd.MarkPersistentFlagRequired(FlagManifests)
+	}
 }
 
 var RootCmd = &cobra.Command{

--- a/kubeprod/cmd/version.go
+++ b/kubeprod/cmd/version.go
@@ -31,7 +31,6 @@ import (
 
 // NB: These are overridden by main()
 var Version = "(dev build)"
-var GitTag = "master"
 
 const (
 	ReleaseNamespace = "kubeprod"

--- a/kubeprod/main.go
+++ b/kubeprod/main.go
@@ -37,11 +37,9 @@ import (
 
 // Overridden at link time by Makefile.
 var version = "(dev build)"
-var gitTag = "master"
 
 func init() {
 	cmd.Version = version
-	cmd.GitTag = gitTag
 }
 
 func main() {

--- a/kubeprod/main.go
+++ b/kubeprod/main.go
@@ -36,12 +36,16 @@ import (
 )
 
 // Overridden at link time by Makefile.
-var version = "(dev build)"
-var releasesBaseUrl = "https://releases.kubeprod.io"
+var version = ""
+var releasesBaseUrl = ""
 
 func init() {
-	cmd.Version = version
-	cmd.ReleasesBaseUrl = releasesBaseUrl
+	if version != "" {
+		cmd.Version = version
+	}
+	if releasesBaseUrl != "" {
+		cmd.ReleasesBaseUrl = releasesBaseUrl
+	}
 }
 
 func main() {

--- a/kubeprod/main.go
+++ b/kubeprod/main.go
@@ -37,9 +37,11 @@ import (
 
 // Overridden at link time by Makefile.
 var version = "(dev build)"
+var releasesBaseUrl = "https://releases.kubeprod.io"
 
 func init() {
 	cmd.Version = version
+	cmd.ReleasesBaseUrl = releasesBaseUrl
 }
 
 func main() {


### PR DESCRIPTION
Changes:
- [x] Publish manifests to S3 bucket
- [x] Default manifest base url set to https://releases.kubeprod.io/files (previously github.com), configurable at build-time.
- [x] `--manifests` flag is optional only for releases
- [x] Removed unused GIT_TAG related code
- [x] availability of https://releases.kubeprod.io endpoint
 
Closes #236