### PR TITLE
ci: set failFast to true in parallel tasks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -249,7 +249,7 @@ spec:
                     }
                 }
             }
-        })
+        }, failFast: true)
 
     def platforms = [:]
 
@@ -478,6 +478,7 @@ gcloud container clusters create ${clusterName} \
         }
     }
 
+    platforms.failFast = true
     parallel platforms
 
     stage('Release') {


### PR DESCRIPTION
`failFast: true` allows us to terminate a CI job as soon as a failure is encountered in parallel tasks