### PR TITLE
docs: removes use of `--manifests` flag from quickstarts

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -43,8 +43,6 @@ On macOS:
   sudo mv bkpr-${BKPR_VERSION}/kubeprod /usr/local/bin/
   ```
 
-Note: The Jsonnet manifests from the release are used while installing BKPR on the cluster.
-
 ### Build from source (Linux / macOS)
 
 To build the `kubeprod` binary from source you need the [Go](https://golang.org/) compiler. Please follow the [Go install guide](https://golang.org/doc/install) to install the compiler on your machine before proceeding with this section.

--- a/docs/quickstart-aks.md
+++ b/docs/quickstart-aks.md
@@ -86,7 +86,6 @@ To bootstrap your Kubernetes cluster with BKPR:
   ```bash
   kubeprod install aks \
     --email ${AZURE_USER} \
-    --manifests ./bkpr-${BKPR_VERSION}/manifests \
     --dns-zone "${AZURE_DNS_ZONE}" \
     --dns-resource-group "${AZURE_RESOURCE_GROUP}"
   ```

--- a/docs/quickstart-gke.md
+++ b/docs/quickstart-gke.md
@@ -114,7 +114,6 @@ To bootstrap your Kubernetes cluster with BKPR:
   ```bash
   kubeprod install gke \
     --email "${GCLOUD_USER}" \
-    --manifests "./bkpr-${BKPR_VERSION}/manifests" \
     --dns-zone "${GCLOUD_DNS_ZONE}" \
     --project "${GCLOUD_PROJECT}" \
     --oauth-client-id "${GCLOUD_OAUTH_CLIENT_KEY}" \


### PR DESCRIPTION
Removes `--manifests` flag from quickstart guides
