### PR TITLE
docs: add quickstart section back to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ The following matrix shows which Kubernetes versions and platforms are supported
 |     `0.3`    |   `1.8`-`1.9`       | Yes | No  |
 |     `1.0`    |   `1.9`-`1.10`      | Yes | Yes |
 
-## Installation
+## ## Quickstart
 
-Please follow the [installation guide](docs/install.md) to install BKPR on your cluster.
+Please use the [installation guide](docs/install.md) to install the `kubeprod` binary before installing BKPR to your cluster.
+
+* [AKS Quickstart](docs/quickstart-aks.md)
+* [GKE Quickstart](docs/quickstart-gke.md)
 
 ## Frequently Asked Questions (FAQ)
 


### PR DESCRIPTION
fixes quickstart link from kubeless.io