### PR TITLE
Bump cert-manager to v0.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The following matrix shows which versions of each component are used and support
 |   Prometheus  |            `2.3.2` |
 |     Kibana    |           `5.6.12` |
 | Elasticsearch |           `5.6.12` |
-|  cert-manager |            `0.3.2` |
+|  cert-manager |            `0.5.2` |
 |  Alertmanager |           `0.15.2` |
 |  ExternalDNS  |            `0.5.4` |
 | nginx-ingress |           `0.19.0` |

--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -105,7 +105,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             default: kube.Container("cert-manager") {
-              image: "bitnami/cert-manager:0.5.0-r36",
+              image: "bitnami/cert-manager:0.5.2-r22",
               args_+: {
                 "cluster-resource-namespace": "$(POD_NAMESPACE)",
                 "leader-election-namespace": "$(POD_NAMESPACE)",


### PR DESCRIPTION
Bumps cert-manager to v0.5.2, which contains a patch to prevent excessive usage of the Let's Encrypt API under certain conditions. More information on this can be found in our release notes 😄 

This also updates the README.md to reflect the actual 'state of the world'!