### PR TITLE
Keep all image versions in a single JSON file.

### DIFF
--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local CERT_MANAGER_IMAGE = "bitnami/cert-manager:%s" % (import "versions.json")["cert-manager"];
 
 {
   p:: "",
@@ -105,7 +106,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             default: kube.Container("cert-manager") {
-              image: "bitnami/cert-manager:0.5.2-r22",
+              image: CERT_MANAGER_IMAGE,
               args_+: {
                 "cluster-resource-namespace": "$(POD_NAMESPACE)",
                 "leader-election-namespace": "$(POD_NAMESPACE)",

--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -18,7 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-local CERT_MANAGER_IMAGE = "bitnami/cert-manager:%s" % (import "versions.json")["cert-manager"];
+local CERT_MANAGER_IMAGE = (import "versions.json")["cert-manager"];
 
 {
   p:: "",

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -20,7 +20,7 @@
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = "bitnami/elasticsearch:5.6.12-r2";
+local ELASTICSEARCH_IMAGE = (import "versions.json")["elasticsearch"];
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)

--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -18,7 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-local EXTERNAL_DNS_IMAGE = "bitnami/external-dns:%s" % (import "versions.json")["external-dns"];
+local EXTERNAL_DNS_IMAGE = (import "versions.json")["external-dns"];
 
 {
   p:: "",

--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local EXTERNAL_DNS_IMAGE = "bitnami/external-dns:%s" % (import "versions.json")["external-dns"];
 
 {
   p:: "",
@@ -76,7 +77,7 @@ local kube = import "../lib/kube.libsonnet";
           serviceAccountName: $.sa.metadata.name,
           containers_+: {
             edns: kube.Container("external-dns") {
-              image: "bitnami/external-dns:0.5.4-r8",
+              image: EXTERNAL_DNS_IMAGE,
               args_+: {
                 sources_:: ["service", "ingress"],
                 "txt-owner-id": this.ownerId,

--- a/manifests/components/fluentd-es.jsonnet
+++ b/manifests/components/fluentd-es.jsonnet
@@ -21,7 +21,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local FLUENTD_ES_IMAGE = "bitnami/fluentd:1.2.2-r22";
+local FLUENTD_ES_IMAGE = (import "versions.json")["fluentd"];
 local FLUENTD_ES_CONF_PATH = "/opt/bitnami/fluentd/conf";
 local FLUENTD_ES_CONFIGD_PATH = "/opt/bitnami/fluentd/conf/config.d";
 local FLUENTD_ES_LOG_FILE = "/opt/bitnami/fluentd/logs/fluentd.log";

--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -21,7 +21,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local GRAFANA_IMAGE = "bitnami/grafana:5.3.4-r6";
+local GRAFANA_IMAGE = (import "versions.json")["grafana"];
 local GRAFANA_DATASOURCES_CONFIG = "/opt/bitnami/grafana/conf/provisioning/datasources";
 local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
 

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -21,7 +21,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local KIBANA_IMAGE = "bitnami/kibana:5.6.12-r15";
+local KIBANA_IMAGE = (import "versions.json")["kibana"];
 
 local strip_trailing_slash(s) = (
   if std.endsWith(s, "/") then

--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -19,7 +19,7 @@
 
 local kube = import "../lib/kube.libsonnet";
 
-local NGNIX_INGRESS_IMAGE = "bitnami/nginx-ingress-controller:0.21.0-r0";
+local NGNIX_INGRESS_IMAGE = (import "versions.json")["nginx-ingress-controller"];
 
 {
   p:: "",

--- a/manifests/components/oauth2-proxy.jsonnet
+++ b/manifests/components/oauth2-proxy.jsonnet
@@ -18,6 +18,7 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
+local OAUTH2_PROXY_IMAGE = (import "versions.json")["oauth2_proxy"];
 
 {
   p:: "",
@@ -51,7 +52,7 @@ local kube = import "../lib/kube.libsonnet";
         spec+: {
           containers_+: {
             proxy: kube.Container("oauth2-proxy") {
-              image: "bitnami/oauth2-proxy:0.20180625.74543-debian-9-r6",
+              image: OAUTH2_PROXY_IMAGE,
               args_+: {
                 "email-domain": "*",
                 "http-address": "0.0.0.0:4180",

--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -21,7 +21,7 @@ local kube = import "../lib/kube.libsonnet";
 local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local PROMETHEUS_IMAGE = "bitnami/prometheus:2.4.3-r31";
+local PROMETHEUS_IMAGE = (import "versions.json")["prometheus"];
 local PROMETHEUS_CONF_MOUNTPOINT = "/opt/bitnami/prometheus/conf/custom";
 local PROMETHEUS_PORT = 9090;
 

--- a/manifests/components/versions.json
+++ b/manifests/components/versions.json
@@ -1,4 +1,11 @@
 {
-    "cert-manager": "0.5.2-r36",
-    "external-dns": "0.5.9-r18"
+    "cert-manager": "bitnami/cert-manager:0.5.2-r36",
+    "external-dns": "bitnami/external-dns:0.5.9-r18",
+    "elasticsearch": "bitnami/elasticsearch:5.6.12-r2",
+    "fluentd": "bitnami/fluentd:1.2.2-r22",
+    "grafana": "bitnami/grafana:5.3.4-r6",
+    "kibana": "bitnami/kibana:5.6.12-r15",
+    "nginx-ingress-controller": "bitnami/nginx-ingress-controller:0.21.0-r0",
+    "oauth2_proxy": "bitnami/oauth2-proxy:0.20180625.74543-debian-9-r6",
+    "prometheus": "bitnami/prometheus:2.4.3-r31"
 }

--- a/manifests/components/versions.json
+++ b/manifests/components/versions.json
@@ -1,6 +1,6 @@
 {
-    "cert-manager": "bitnami/cert-manager:0.5.2-r36",
-    "external-dns": "bitnami/external-dns:0.5.9-r18",
+    "cert-manager": "bitnami/cert-manager:0.5.2-r22",
+    "external-dns": "bitnami/external-dns:0.5.4-r8",
     "elasticsearch": "bitnami/elasticsearch:5.6.12-r2",
     "fluentd": "bitnami/fluentd:1.2.2-r22",
     "grafana": "bitnami/grafana:5.3.4-r6",

--- a/manifests/components/versions.json
+++ b/manifests/components/versions.json
@@ -1,0 +1,4 @@
+{
+    "cert-manager": "0.5.2-r36",
+    "external-dns": "0.5.9-r18"
+}


### PR DESCRIPTION
This should make release engineering and automated updates of
image versions easier.

Also, bump versions for:

* cert-manager
* external-dns