### PR TITLE
Added instructions for clean  up the sidecar container 

### DIFF
--- a/docs/migration-guides/prometheus-migration.md
+++ b/docs/migration-guides/prometheus-migration.md
@@ -115,12 +115,14 @@ local stack = {
     spec+: {
       template+: {
         spec+: {
-          containers: containers_obj(super.containers) {
-            [rsync_container_name]: rsync_container,
-            [prometheus_container_name]+: {
-              args+: ["--web.enable-admin-api"],
+          containers: kube.objectValues(
+            containers_obj(super.containers) {
+              [rsync_container_name]: rsync_container,
+              [prometheus_container_name]+: {
+                args+: ["--web.enable-admin-api"],
+              },
             },
-          },
+          ),
         },
       },
     },

--- a/docs/migration-guides/prometheus-migration.md
+++ b/docs/migration-guides/prometheus-migration.md
@@ -356,7 +356,7 @@ level=info ts=2018-12-05T11:00:09.952061917Z caller=head.go:446 component=tsdb m
 
 It is good practice to leave the old Prometheus database running until you are satisfied that the migration has completed without errors.
 
-## Step 6: Cleaning up sidecar container
+## Step 6: Clean up sidecar container
 
 Once you finished the migration, it's time to cleaning up the sidecar containers we added to help us with the TSDB migration. To do so, remove the block related to the rsync container:
 


### PR DESCRIPTION
and expose prometheus-rsync service.

Some minor Markdown lint fixes too. 

I guess we can add the service as part of the `kubeprod-manifests.jsonnet` modifications, but I tried to make it easy to understand by the final user as an explicit step on the procedure. 