### PR TITLE
ci: use preemptible vm's for gke jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -407,6 +407,7 @@ gcloud container clusters create ${clusterName} \
  --machine-type n1-standard-2 \
  --num-nodes 3 \
  --zone ${zone} \
+ --preemptible \
  --labels 'platform=${gcpLabel(platform)},branch=${gcpLabel(BRANCH_NAME)},build=${gcpLabel(BUILD_TAG)}'
 """
 


### PR DESCRIPTION
Preemptible VM's last a maximum of 24 hours and are priced lower than
standard Compute Engine VMs. As the CI jobs create short-lived clusters
we can use preemptible vm's for it's use and signiificantly reduce ci
costs (upto 80%).

ref: https://cloud.google.com/preemptible-vms/