### PR TITLE
Enable bors-ng

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,0 +1,14 @@
+# See https://bors.tech/documentation/
+
+status = [
+  "continuous-integration/jenkins/branch"
+]
+
+pr_status = [
+  "continuous-integration/jenkins/pr-merge"
+]
+
+required_approvals = 1
+
+# Extend to 3h - default is 1h
+timeout_sec = 10800


### PR DESCRIPTION
Integration tests take an unusually long time with this project, so we
want a bot to take approved PRs, do a final rebase and test, and only
_then_ merge if there are no issues.

TL;DR: Type `bors r+` on a line by itself to say "PR should be merged".
See https://bors.tech/documentation/ for other supported bot commands.