### PR TITLE
Upgrade addon-resizer to 1.8.4

### DIFF
--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -515,7 +515,7 @@ local get_cm_web_hook_url = function(port, path) (
                 },
               },
               resizer: kube.Container("addon-resizer") {
-                image: "gcr.io/google_containers/addon-resizer:1.0",
+                image: "k8s.gcr.io/addon-resizer:1.8.4",
                 command: ["/pod_nanny"],
                 args_+: {
                   container: spec.containers[0].name,


### PR DESCRIPTION
Significantly newer version than our previous ancient 1.0.
Fixes #85 and many other minor issues.