### PR TITLE
ExternalDNS: Track provenance in non-conflicting TXT name

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -80,6 +80,8 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
               image: EXTERNAL_DNS_IMAGE,
               args_+: {
                 sources_:: ["service", "ingress"],
+                registry: "txt",
+                "txt-prefix": "_externaldns",
                 "txt-owner-id": this.ownerId,
                 "domain-filter": this.ownerId,
               },


### PR DESCRIPTION
Previously ExternalDNS stored a TXT record alongside each managed DNS
record, to avoid stomping on DNS entries that were created
elsewhere (good).

These TXT records conflicted with CNAME records, since they had the
same name (bad).

Configure ExternalDNS to store the TXT record in a different name.
Now the TXT metadata record for `foo` will be stored as
`_externaldns.foo`.