### PR TITLE
Update Kibana to 5.6.15 due to a security bug.

### DIFF
--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -6,7 +6,7 @@
     "external-dns": "bitnami/external-dns:0.5.11-r1",
     "fluentd": "bitnami/fluentd:1.3.3-r23",
     "grafana": "bitnami/grafana:5.4.3-r18",
-    "kibana": "bitnami/kibana:5.6.14-r12",
+    "kibana": "bitnami/kibana:5.6.15-r0",
     "nginx-ingress-controller": "bitnami/nginx-ingress-controller:0.21.0-r12",
     "oauth2_proxy": "bitnami/oauth2-proxy:3.1.0-r1",
     "prometheus": "bitnami/prometheus:2.7.1-r1"


### PR DESCRIPTION
Kibana versions before 5.6.15 and 6.6.1 had a cross-site scripting (XSS)
vulnerability that could allow an attacker to obtain sensitive information
from or perform destructive actions on behalf of other Kibana users.

https://discuss.elastic.co/t/elastic-stack-6-6-1-and-5-6-15-security-update/169077