### PR TITLE
Allow oauth2_proxy to be used from other namespaces

### DIFF
--- a/docs/migration-guides/bkpr-1.2-migration-guide.md
+++ b/docs/migration-guides/bkpr-1.2-migration-guide.md
@@ -11,6 +11,7 @@ This document is for users who want to upgrade their Kubernetes clusters to BKPR
 Making the move to BKPR v1.2 is a simple process that involves the following steps:
 
 1. Migrate Kibana index to 6.0
+1. Add new OAuth2 redirect URI to cloud identity provider
 1. Upgrade to BKPR v1.2
 
 ## Migrate Kibana index to 6.0
@@ -28,6 +29,34 @@ The [official Kibana 6 index migration guide](https://www.elastic.co/guide/en/ki
 Access the Kibana console editor by visiting `https://kibana.my-domain.com/app/kibana#/dev_tools/console`* and execute the steps listed in the [Kibana index migration guide](https://www.elastic.co/guide/en/kibana/6.0/migrating-6.0-index.html#migrating-6.0-index).
 
 _*Replace `my-domain.com` in the above URL with the DNS suffix specified while installing BKPR_
+
+## Add new OAuth2 redirect URI to cloud identity provider
+
+BKPR v1.2 simplifies the OAuth2 setup, replacing multiple
+service-specific OAuth2 redirect URIs with a single URL.  Before
+upgrading to BKPR v1.2, the new redirect URI will need to be added to
+the existing list configured in your cloud settings.
+
+### For GKE:
+
+1. Go to <https://console.developers.google.com/apis/credentials>.
+1. Select the project from the drop down menu.
+1. Select the existing OAuth 2.0 client ID used for BKPR.
+1. Add the following authorised redirect URI to the existing list and
+   press __Save__ .
+      + https://auth.${BKPR_DNS_ZONE}/oauth2/callback
+
+  > Replace `${BKPR_DNS_ZONE}` with the DNS zone used for your BKPR cluster
+
+### For AKS:
+
+1. ```bash
+   az ad app update \
+     --id https://oauth.${BKPR_DNS_ZONE}/oauth2 \
+     --reply-urls https://auth.${BKPR_DNS_ZONE}/oauth2/callback
+   ```
+
+  > Replace `${BKPR_DNS_ZONE}` with the DNS zone used for your BKPR cluster
 
 ## Upgrade to BKPR v1.2
 

--- a/docs/quickstart-gke.md
+++ b/docs/quickstart-gke.md
@@ -84,6 +84,7 @@ In this section, you will deploy a Google Kubernetes Engine (GKE) cluster using 
       + https://prometheus.${BKPR_DNS_ZONE}/oauth2/callback
       + https://kibana.${BKPR_DNS_ZONE}/oauth2/callback
       + https://grafana.${BKPR_DNS_ZONE}/oauth2/callback
+      + https://auth.${BKPR_DNS_ZONE}/oauth2/callback
 
   > Replace `${BKPR_DNS_ZONE}` with the value of the `BKPR_DNS_ZONE` environment variable*
 

--- a/kubeprod/pkg/aks/platform.go
+++ b/kubeprod/pkg/aks/platform.go
@@ -319,10 +319,8 @@ func (conf *AKSConfig) Generate(ctx context.Context) error {
 			return err
 		}
 
-		oauthHosts := []string{"prometheus", "kibana", "grafana"}
-		replyUrls := make([]string, len(oauthHosts))
-		for i, h := range oauthHosts {
-			replyUrls[i] = fmt.Sprintf("https://%s.%s/oauth2/callback", h, conf.DnsZone)
+		replyUrls := []string{
+			fmt.Sprintf("https://auth.%s/oauth2/callback", conf.DnsZone),
 		}
 
 		// az ad app create ...

--- a/kubeprod/pkg/eks/platform.go
+++ b/kubeprod/pkg/eks/platform.go
@@ -137,7 +137,7 @@ func (conf *Config) getUserPolicy() (*string, error) {
 	b, err := json.Marshal(&PolicyDocument{
 		Version: "2012-10-17",
 		Statement: []StatementEntry{
-			StatementEntry{
+			{
 				Effect: "Allow",
 				Action: []string{
 					"route53:GetHostedZone",
@@ -148,7 +148,7 @@ func (conf *Config) getUserPolicy() (*string, error) {
 				},
 				Resource: "*",
 			},
-			StatementEntry{
+			{
 				Effect: "Allow",
 				// Allows for DeleteItem, GetItem, PutItem, Scan, and UpdateItem
 				Action: []string{
@@ -363,9 +363,7 @@ func (conf *Config) getUserPoolClient(svc *cognitoidentityprovider.CognitoIdenti
 			aws.String("profile"),
 		},
 		CallbackURLs: []*string{
-			aws.String(fmt.Sprintf("https://grafana.%s/oauth2/callback", conf.DNSZone)),
-			aws.String(fmt.Sprintf("https://kibana.%s/oauth2/callback", conf.DNSZone)),
-			aws.String(fmt.Sprintf("https://prometheus.%s/oauth2/callback", conf.DNSZone)),
+			aws.String(fmt.Sprintf("https://auth.%s/oauth2/callback", conf.DNSZone)),
 		},
 		SupportedIdentityProviders: []*string{
 			aws.String("COGNITO"),

--- a/kubeprod/pkg/gke/platform.go
+++ b/kubeprod/pkg/gke/platform.go
@@ -398,10 +398,8 @@ func (conf *GKEConfig) Generate(ctx context.Context) error {
 			}
 		}
 
-		oauthHosts := []string{"prometheus", "kibana", "grafana"}
-		replyUrls := make([]string, len(oauthHosts))
-		for i, h := range oauthHosts {
-			replyUrls[i] = fmt.Sprintf("https://%s.%s/oauth2/callback", h, conf.DnsZone)
+		replyUrls := []string{
+			fmt.Sprintf("https://auth.%s/oauth2/callback", conf.DnsZone),
 		}
 
 		if clientID == "" || clientSecret == "" {

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -66,11 +66,7 @@ local strip_trailing_slash(s) = (
               },
               env_+: {
                 KIBANA_ELASTICSEARCH_URL: $.es.svc.host,
-
-                local route = $.ingress.spec.rules[0].http.paths[0],
-                // Make sure we got the correct route
-                assert route.backend == $.svc.name_port,
-                SERVER_BASEPATH: strip_trailing_slash(route.path),
+                SERVER_BASEPATH: strip_trailing_slash($.ingress.kibanaPath),
                 KIBANA_HOST: "0.0.0.0",
                 XPACK_MONITORING_ENABLED: "false",
                 XPACK_SECURITY_ENABLED: "false",
@@ -92,13 +88,14 @@ local strip_trailing_slash(s) = (
   ingress: utils.AuthIngress($.p + "kibana-logging") + $.metadata {
     local this = self,
     host:: error "host is required",
+    kibanaPath:: "/",
     spec+: {
       rules+: [
         {
           host: this.host,
           http: {
             paths: [
-              { path: "/", backend: $.svc.name_port },
+              { path: this.kibanaPath, backend: $.svc.name_port },
             ],
           },
         },

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -67,7 +67,7 @@ local strip_trailing_slash(s) = (
               env_+: {
                 KIBANA_ELASTICSEARCH_URL: $.es.svc.host,
 
-                local route = $.ingress.spec.rules[1].http.paths[0],
+                local route = $.ingress.spec.rules[0].http.paths[0],
                 // Make sure we got the correct route
                 assert route.backend == $.svc.name_port,
                 SERVER_BASEPATH: strip_trailing_slash(route.path),

--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -164,8 +164,8 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
               securityContext: {
                 runAsUser: 1001,
                 capabilities: {
-                  drop: ['ALL'],
-                  add: ['NET_BIND_SERVICE'],
+                  drop: ["ALL"],
+                  add: ["NET_BIND_SERVICE"],
                 },
               },
               env_+: {
@@ -175,7 +175,8 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
               args_+: {
                 local fqname(o) = "%s/%s" % [o.metadata.namespace, o.metadata.name],
                 configmap: fqname($.config),
-                // publish-service requires Service.Status.LoadBalancer.Ingress
+                // NB: publish-service requires Service.Status.LoadBalancer.Ingress
+                // to be set correctly.
                 "publish-service": fqname($.svc),
                 "tcp-services-configmap": fqname($.tcpconf),
                 "udp-services-configmap": fqname($.udpconf),

--- a/manifests/platforms/aks.jsonnet
+++ b/manifests/platforms/aks.jsonnet
@@ -99,6 +99,10 @@ local grafana = import "../components/grafana.jsonnet";
       data_+: $.config.oauthProxy,
     },
 
+    ingress+: {
+      host: "auth." + $.external_dns_zone_name,
+    },
+
     deploy+: {
       spec+: {
         template+: {

--- a/manifests/platforms/eks.jsonnet
+++ b/manifests/platforms/eks.jsonnet
@@ -98,6 +98,10 @@ local grafana = import "../components/grafana.jsonnet";
       data_+: $.config.oauthProxy,
     },
 
+    ingress+: {
+      host: "auth." + $.external_dns_zone_name,
+    },
+
     deploy+: {
       spec+: {
         template+: {

--- a/manifests/platforms/gke.jsonnet
+++ b/manifests/platforms/gke.jsonnet
@@ -99,6 +99,10 @@ local grafana = import "../components/grafana.jsonnet";
       data_+: $.config.oauthProxy,
     },
 
+    ingress+: {
+      host: "auth." + $.external_dns_zone_name,
+    },
+
     gcreds: kube.Secret(oauth2.p+"oauth2-proxy-google-credentials") + oauth2.metadata {
       data_+: {
         "credentials.json": $.config.oauthProxy.google_service_account_json,

--- a/tests/vendor/github.com/pusher/oauth2_proxy/LICENSE
+++ b/tests/vendor/github.com/pusher/oauth2_proxy/LICENSE
@@ -1,0 +1,17 @@
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/tests/vendor/github.com/pusher/oauth2_proxy/cookie/cookies.go
+++ b/tests/vendor/github.com/pusher/oauth2_proxy/cookie/cookies.go
@@ -1,0 +1,128 @@
+package cookie
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// cookies are stored in a 3 part (value + timestamp + signature) to enforce that the values are as originally set.
+// additionally, the 'value' is encrypted so it's opaque to the browser
+
+// Validate ensures a cookie is properly signed
+func Validate(cookie *http.Cookie, seed string, expiration time.Duration) (value string, t time.Time, ok bool) {
+	// value, timestamp, sig
+	parts := strings.Split(cookie.Value, "|")
+	if len(parts) != 3 {
+		return
+	}
+	sig := cookieSignature(seed, cookie.Name, parts[0], parts[1])
+	if checkHmac(parts[2], sig) {
+		ts, err := strconv.Atoi(parts[1])
+		if err != nil {
+			return
+		}
+		// The expiration timestamp set when the cookie was created
+		// isn't sent back by the browser. Hence, we check whether the
+		// creation timestamp stored in the cookie falls within the
+		// window defined by (Now()-expiration, Now()].
+		t = time.Unix(int64(ts), 0)
+		if t.After(time.Now().Add(expiration*-1)) && t.Before(time.Now().Add(time.Minute*5)) {
+			// it's a valid cookie. now get the contents
+			rawValue, err := base64.URLEncoding.DecodeString(parts[0])
+			if err == nil {
+				value = string(rawValue)
+				ok = true
+				return
+			}
+		}
+	}
+	return
+}
+
+// SignedValue returns a cookie that is signed and can later be checked with Validate
+func SignedValue(seed string, key string, value string, now time.Time) string {
+	encodedValue := base64.URLEncoding.EncodeToString([]byte(value))
+	timeStr := fmt.Sprintf("%d", now.Unix())
+	sig := cookieSignature(seed, key, encodedValue, timeStr)
+	cookieVal := fmt.Sprintf("%s|%s|%s", encodedValue, timeStr, sig)
+	return cookieVal
+}
+
+func cookieSignature(args ...string) string {
+	h := hmac.New(sha1.New, []byte(args[0]))
+	for _, arg := range args[1:] {
+		h.Write([]byte(arg))
+	}
+	var b []byte
+	b = h.Sum(b)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func checkHmac(input, expected string) bool {
+	inputMAC, err1 := base64.URLEncoding.DecodeString(input)
+	if err1 == nil {
+		expectedMAC, err2 := base64.URLEncoding.DecodeString(expected)
+		if err2 == nil {
+			return hmac.Equal(inputMAC, expectedMAC)
+		}
+	}
+	return false
+}
+
+// Cipher provides methods to encrypt and decrypt cookie values
+type Cipher struct {
+	cipher.Block
+}
+
+// NewCipher returns a new aes Cipher for encrypting cookie values
+func NewCipher(secret []byte) (*Cipher, error) {
+	c, err := aes.NewCipher(secret)
+	if err != nil {
+		return nil, err
+	}
+	return &Cipher{Block: c}, err
+}
+
+// Encrypt a value for use in a cookie
+func (c *Cipher) Encrypt(value string) (string, error) {
+	ciphertext := make([]byte, aes.BlockSize+len(value))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return "", fmt.Errorf("failed to create initialization vector %s", err)
+	}
+
+	stream := cipher.NewCFBEncrypter(c.Block, iv)
+	stream.XORKeyStream(ciphertext[aes.BlockSize:], []byte(value))
+	return base64.StdEncoding.EncodeToString(ciphertext), nil
+}
+
+// Decrypt a value from a cookie to it's original string
+func (c *Cipher) Decrypt(s string) (string, error) {
+	encrypted, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", fmt.Errorf("failed to decrypt cookie value %s", err)
+	}
+
+	if len(encrypted) < aes.BlockSize {
+		return "", fmt.Errorf("encrypted cookie value should be "+
+			"at least %d bytes, but is only %d bytes",
+			aes.BlockSize, len(encrypted))
+	}
+
+	iv := encrypted[:aes.BlockSize]
+	encrypted = encrypted[aes.BlockSize:]
+	stream := cipher.NewCFBDecrypter(c.Block, iv)
+	stream.XORKeyStream(encrypted, encrypted)
+
+	return string(encrypted), nil
+}

--- a/tests/vendor/github.com/pusher/oauth2_proxy/cookie/nonce.go
+++ b/tests/vendor/github.com/pusher/oauth2_proxy/cookie/nonce.go
@@ -1,0 +1,17 @@
+package cookie
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+// Nonce generates a random 16 byte string to be used as a nonce
+func Nonce() (nonce string, err error) {
+	b := make([]byte, 16)
+	_, err = rand.Read(b)
+	if err != nil {
+		return
+	}
+	nonce = fmt.Sprintf("%x", b)
+	return
+}

--- a/tests/vendor/vendor.json
+++ b/tests/vendor/vendor.json
@@ -513,6 +513,12 @@
 			"revisionTime": "2018-03-12T05:41:25Z"
 		},
 		{
+			"checksumSHA1": "rG9Pp6KrdR37TyROnXx+r1CUKs4=",
+			"path": "github.com/pusher/oauth2_proxy/cookie",
+			"revision": "c83335324e551e4d16f3838c0b570fc76416adf3",
+			"revisionTime": "2019-02-17T11:56:05Z"
+		},
+		{
 			"checksumSHA1": "KnNrKeXkIcdOkWXlK57sn4Jn8SE=",
 			"path": "github.com/spf13/pflag",
 			"revision": "1ce0cc6db4029d97571db82f85092fccedb572ce",


### PR DESCRIPTION
Improve the oauth2_proxy setup to be able to protect Ingress objects
from other k8s namespaces too.

This change will protect any Ingress, provided it:
a) uses a hostname within the zone managed by BKPR, and
b) includes the required Ingress annotations (see below).

The key changes involve:
- oauth2_proxy (encrypted) cookie is now exposed to the full DNS
  zone given by `--dns-zone`
- Upstream identity provider setup is simplified to only redirect to
  https://auth.${dns_zone}/oauth2/callback
- oauth2_proxy setup is modified to perform redirects to any host
  within ${dns_zone}

To protect your Ingress with the BKPR-managed oauth2 stack, your
Ingress requires the following annotations (with `${dns_zone}`
replaced accordingly. Note other $... strings should remain as-is).
If using jsonnet, deriving from `utils.AuthIngress(name)` will do the
right thing.
```
annotations:
  kubernetes.io/ingress.class: nginx
  nginx.ingress.kubernetes.io/auth-signin: https://auth.${dns_zone}/oauth2/start?rd=%2F$server_name$escaped_request_uri
  nginx.ingress.kubernetes.io/auth-url: https://auth.${dns_zone}/oauth2/auth
  # optional, if you want access to the authenticated user/email name
  nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-User, X-Auth-Request-Email
```

### Upgrade impact:
The Oauth2 redirect URI configured in cloud setups needs to be changed
to `https://auth.${dns_zone}/oauth2/callback` (with `${dns_zone}` replaced
appropriately).  Other redirect URIs will no longer be used after this
change, and may be removed (they are also safe to leave configured).

Fixes #317