### PR TITLE
GKE no longer supports 1.10

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -258,7 +258,7 @@ spec:
 
     // See:
     //  gcloud container get-server-config
-    def gkeKversions = ["1.10", "1.11"]
+    def gkeKversions = ["1.11"]
     for (x in gkeKversions) {
         def kversion = x  // local bind required because closures
         def platform = "gke-" + kversion


### PR DESCRIPTION
https://cloud.google.com/kubernetes-engine/release-notes#february-18-2019

```
Versions no longer available
The following versions are no longer available for new clusters or
upgrades to existing cluster masters:

1.10.x
```

This means GKE currently _only_ supports 1.11.x (masters) :/