### PR TITLE
external-dns: Add trailing '.' to txt-prefix

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -81,7 +81,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
               args_+: {
                 sources_:: ["service", "ingress"],
                 registry: "txt",
-                "txt-prefix": "_externaldns",
+                "txt-prefix": "_externaldns.",
                 "txt-owner-id": this.ownerId,
                 "domain-filter": this.ownerId,
               },


### PR DESCRIPTION
This is an improvement/fix to #343, to achieve the originally stated
goal.  external-dns prepends _exactly_ the txt-prefix to created TXT
metadata records, so the `.` separator needs to be added explicitly.