### PR TITLE
Update deployment when ext-dns or oauth2_proxy secret changes

### DIFF
--- a/manifests/components/oauth2-proxy.jsonnet
+++ b/manifests/components/oauth2-proxy.jsonnet
@@ -31,7 +31,7 @@ local OAUTH2_PROXY_IMAGE = (import "images.json")["oauth2_proxy"];
     },
   },
 
-  secret: kube.Secret($.p + "oauth2-proxy") + $.metadata {
+  secret: utils.HashedSecret($.p + "oauth2-proxy") + $.metadata {
     data_+: {
       client_id: error "client_id is required",
       client_secret: error "client_secret is required",

--- a/manifests/lib/utils.libsonnet
+++ b/manifests/lib/utils.libsonnet
@@ -93,4 +93,16 @@ local kube = import "kube.libsonnet";
       },
     },
   },
+
+  local hashed = {
+    local this = self,
+    metadata+: {
+      local hash = std.substr(std.md5(std.toString(this.data)), 0, 7),
+      local orig_name = super.name,
+      name: orig_name + "-" + hash,
+      labels+: {name: orig_name},
+    },
+  },
+  HashedConfigMap(name):: kube.ConfigMap(name) + hashed,
+  HashedSecret(name):: kube.Secret(name) + hashed,
 }

--- a/manifests/platforms/aks.jsonnet
+++ b/manifests/platforms/aks.jsonnet
@@ -20,6 +20,7 @@
 // Top-level file for Azure AKS
 
 local kube = import "../lib/kube.libsonnet";
+local utils = import "../lib/utils.libsonnet";
 local version = import "../components/version.jsonnet";
 local cert_manager = import "../components/cert-manager.jsonnet";
 local edns = import "../components/externaldns.jsonnet";
@@ -51,7 +52,7 @@ local grafana = import "../components/grafana.jsonnet";
   },
 
   edns: edns {
-    azconf: kube.Secret(edns.p + "external-dns-azure-conf") {
+    azconf: utils.HashedSecret(edns.p + "external-dns-azure-conf") {
       metadata+: { namespace: "kubeprod" },
       data_+: {
         azure:: $.config.externalDns,

--- a/manifests/platforms/eks.jsonnet
+++ b/manifests/platforms/eks.jsonnet
@@ -20,6 +20,7 @@
 // Top-level file for AWS EKS
 
 local kube = import "../lib/kube.libsonnet";
+local utils = import "../lib/utils.libsonnet";
 local version = import "../components/version.jsonnet";
 local cert_manager = import "../components/cert-manager.jsonnet";
 local edns = import "../components/externaldns.jsonnet";
@@ -56,7 +57,7 @@ local grafana = import "../components/grafana.jsonnet";
     // NOTE: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
     // for additional information on how to use environment variables to configure a particular user when accessing
     // the AWS API.
-    secret: kube.Secret(this.p + "external-dns-aws-conf") {
+    secret: utils.HashedSecret(this.p + "external-dns-aws-conf") {
       metadata+: {
         namespace: "kubeprod",
       },

--- a/manifests/platforms/gke.jsonnet
+++ b/manifests/platforms/gke.jsonnet
@@ -20,6 +20,7 @@
 // Top-level file for Google GKE
 
 local kube = import "../lib/kube.libsonnet";
+local utils = import "../lib/utils.libsonnet";
 local version = import "../components/version.jsonnet";
 local cert_manager = import "../components/cert-manager.jsonnet";
 local edns = import "../components/externaldns.jsonnet";
@@ -51,7 +52,7 @@ local grafana = import "../components/grafana.jsonnet";
   },
 
   edns: edns {
-    gcreds: kube.Secret($.edns.p+"external-dns-google-credentials") + $.edns.metadata {
+    gcreds: utils.HashedSecret($.edns.p+"external-dns-google-credentials") + $.edns.metadata {
       data_+: {
         "credentials.json": $.config.externalDns.credentials,
       },
@@ -103,7 +104,7 @@ local grafana = import "../components/grafana.jsonnet";
       host: "auth." + $.external_dns_zone_name,
     },
 
-    gcreds: kube.Secret(oauth2.p+"oauth2-proxy-google-credentials") + oauth2.metadata {
+    gcreds: utils.HashedSecret(oauth2.p+"oauth2-proxy-google-credentials") + oauth2.metadata {
       data_+: {
         "credentials.json": $.config.oauthProxy.google_service_account_json,
       },

--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -368,8 +368,10 @@ var _ = Describe("Ingress", func() {
 				client, err := httpClient(&map[string]string{})
 				Expect(err).NotTo(HaveOccurred())
 
-				secret, err := c.CoreV1().Secrets("kubeprod").Get("oauth2-proxy", metav1.GetOptions{})
+				secrets, err := c.CoreV1().Secrets("kubeprod").List(metav1.ListOptions{LabelSelector: "name=oauth2-proxy"})
 				Expect(err).NotTo(HaveOccurred())
+				Expect(secrets.Items).To(HaveLen(1))
+				secret := secrets.Items[0]
 
 				// Inject an auth cookie
 				now := time.Now()


### PR DESCRIPTION
Add new `HashedConfigMap` and `HashedSecret` derived objects that
modify their `metadata.name` based on a hash of `self.data`.

Change external-dns and oauth2_proxy `Secret`s to `HashedSecret`,
which will force a `Deployment` update whenever the contents (name) of
the referenced `Secret` changes.

Going forward, we should use this pattern for any processes that don't
re-read a modified mounted file and use a configmap/secret that is
static after creation.

Fixes #64