### PR TITLE
Increase nginx-ingress + oauth2_proxy to replicas=2

### DIFF
--- a/manifests/lib/utils.libsonnet
+++ b/manifests/lib/utils.libsonnet
@@ -45,6 +45,24 @@ local kube = import "kube.libsonnet";
     std.join(".", tail)
   ),
 
+  // affinity=weakNodeDiversity to Try to spread across separate
+  // nodes/zones (for fault-tolerance)
+  weakNodeDiversity(selector):: {
+    podAntiAffinity+: {
+      preferredDuringSchedulingIgnoredDuringExecution+: [{
+        weight: 70,
+        podAffinityTerm: {
+          labelSelector: selector,
+          topologyKey: k,
+        },
+      } for k in [
+        "kubernetes.io/hostname",
+        "failure-domain.beta.kubernetes.io/zone",
+        "failure-domain.beta.kubernetes.io/region",
+      ]],
+    },
+  },
+
   TlsIngress(name):: kube.Ingress(name) {
     local this = self,
     metadata+: {


### PR DESCRIPTION
nginx-ingress and oauth2_proxy are expected to be in the serving path,
and so should be redundant to single-machine failure (as per the BKPR
default HA target).

Accordingly:
- increase replicas for each to 2
- add (weak) host anti-affinity
- configure a `PodDisruptionBudget` that ensures at least 1 replica of
  each is healthy before draining a node.

Fixes #373