### PR TITLE
ci: specify `DOCKER_CONFIG` env variable for kaniko

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,8 +191,11 @@ spec:
     command:
     - 'cat'
   - name: 'kaniko'
-    image: 'gcr.io/kaniko-project/executor:debug-v0.8.0'
+    image: 'gcr.io/kaniko-project/executor:debug-v0.9.0'
     tty: true
+    env:
+    - name: 'DOCKER_CONFIG'
+      value: '/root/.docker'
     command:
     - '/busybox/cat'
     volumeMounts:


### PR DESCRIPTION
kaniko does not appear to pick docker hub credentials placed at
`/root/.docker/` anymore. As a result the release stage was not able to
push images to the docker registry. In this PR we explicitly specify the
path to the docker `config.json` file in the `DOCKER_CONFIG` variable.

We've also updated the kaniko version in this PR.