### PR TITLE
ci: remove use of pre-emptible vms in GKE

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -319,7 +319,6 @@ spec:
                                                         --machine-type n1-standard-2                \
                                                         --num-nodes 3                               \
                                                         --zone ${zone}                              \
-                                                        --preemptible                               \
                                                         --labels 'platform=${gcpLabel(platform)},branch=${gcpLabel(BRANCH_NAME)},build=${gcpLabel(BUILD_TAG)},team=bkpr,created_by=jenkins-bkpr'
                                                     """
                                                     sh "gcloud container clusters get-credentials ${clusterName} --zone ${zone} --project ${project}"


### PR DESCRIPTION
We've been seeing frequent failure in the cluster set up on GKE in the
CI which are not observed during development. This PR tests if removing
the usage of pre-emptible vms makes any difference