### PR TITLE
feat: Add customize guide for Grafana provisioned dashboards and add code improvements to components/grafana.jsonnet

### DIFF
--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -104,14 +104,14 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
         disableDeletion: false,
         editable: false,
         options: {
-          path: GRAFANA_DASHBOARDS_CONFIG + "/kubernetes",
+          path: utils.path_join(GRAFANA_DASHBOARDS_CONFIG, "kubernetes"),
         },
       },
     },
     data+: {
       _config:: {
         apiVersion: 1,
-        providers: [{name: kv[0]} + kv[1] for kv in kube.objectItems(this.dashboard_provider)],
+        providers: kube.mapToNamedList(this.dashboard_provider),
       },
       "dashboards_provider.yml": kubecfg.manifestYaml(self._config),
     },


### PR DESCRIPTION
I was missing the guide to customise the Grafana provisioned dashboards, so it is added here.
Also, feedback that @anguslees gave me in #500 has been applied here.

I'm still thinking on a good way to test the Grafana dashboards, will come with another PR with more improvements :) 

Cheers