### PR TITLE
manifests: updated RBAC permissions for external-dns

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -48,7 +48,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
       {
         apiGroups: [""],
         resources: ["nodes"],
-        verbs: ["list"],
+        verbs: ["get","watch","list"],
       },
     ],
   },


### PR DESCRIPTION
ref: https://github.com/kubernetes-incubator/external-dns/issues/990