### PR TITLE
ci: ignore cluster deletion errors for EKS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -593,7 +593,7 @@ spec:
                                                     }
                                                 }
                                                 container('eksctl') {
-                                                    sh "eksctl delete cluster --name ${clusterName}"
+                                                    sh "eksctl delete cluster --name ${clusterName} --timeout 10m0s || true"
                                                 }
                                             }
                                             // dnsSetup


### PR DESCRIPTION
It has been observed `cluster delete` generally takes less than 5 mins to successfully delete the cluster. Another observation is when it takes more than 5 mins, the deletion will fail. So waiting 20mins (default) here is a big waste of time.  I've lowered it to a 10mins instead.