### PR TITLE
tests: optimize retry timeouts

### DIFF
--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Ingress", func() {
 				}
 
 				return lbAddr, nil
-			}, "20m", "5s").
+			}, "5m", "5s").
 				ShouldNot(WithTransform(isPrivateIP, BeTrue()))
 		})
 
@@ -249,7 +249,7 @@ var _ = Describe("Ingress", func() {
 
 				resp, err = getURL(client, url)
 				return resp, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(statusCode, Equal(200)))
 
 			defer resp.Body.Close()
@@ -295,7 +295,7 @@ var _ = Describe("Ingress", func() {
 			Eventually(func() (*http.Response, error) {
 				resp, err = getURL(client, url)
 				return resp, err
-			}, "30m", "5s").
+			}, "10m", "5s").
 				Should(WithTransform(statusCode, Equal(200)))
 
 			defer resp.Body.Close()
@@ -336,7 +336,7 @@ var _ = Describe("Ingress", func() {
 					// NB: will follow redirects
 					resp, err = getURL(client, testUrl)
 					return resp, err
-				}, "20m", "5s").
+				}, "10m", "5s").
 					Should(WithTransform(statusCode, Or(Equal(200), Equal(400))))
 
 				fmt.Fprintf(GinkgoWriter, "Response:\n%#v", resp)
@@ -400,7 +400,7 @@ var _ = Describe("Ingress", func() {
 					// NB: will follow redirects
 					resp, err = getURL(client, testUrl)
 					return resp, err
-				}, "20m", "5s").
+				}, "10m", "5s").
 					Should(WithTransform(statusCode, Equal(200)))
 
 				fmt.Fprintf(GinkgoWriter, "Response:\n%#v", resp)

--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Logging", func() {
 				resp := apiResponse{}
 				json.Unmarshal(resultRaw, &resp)
 				return &resp, err
-			}, "15m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(totalHits, BeNumerically(">", 0)))
 		})
 	})

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &series)
 
 				return series, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countSeries, BeNumerically(">", 0)))
 
 			Expect(series[0].Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))
@@ -193,7 +193,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &managers)
 
 				return managers.Active, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countEndpoints, BeNumerically(">", 0)))
 
 			Expect(managers.Active[0].Url).To(ContainSubstring(am_path + "/api/v1/alerts"))
@@ -223,7 +223,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &series)
 
 				return series, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countSeries, BeNumerically(">", 0)))
 
 			Expect(series[0].Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))
@@ -247,7 +247,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &alerts)
 
 				return alerts, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countAlerts, BeNumerically(">", 0)))
 
 			Expect(alerts[0].Label.Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))


### PR DESCRIPTION
Successful passes of the ci tests generally conclude in 5 - 10mins. It has been observered that
when it takes longer the tests are bound to fail. Some of our tests use 30m retry timeouts
which is lot of time wasted hoping that a failing test will pass.

This commit optimizes the retry timeouts for all tests to more realistic values thereby reducing
the time spent by a job in the CI environment