### PR TITLE
[ci/backports/1.2] backport ci updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -595,7 +595,7 @@ spec:
                                                     }
                                                 }
                                                 container('eksctl') {
-                                                    sh "eksctl delete cluster --name ${clusterName}"
+                                                    sh "eksctl delete cluster --name ${clusterName} --timeout 10m0s || true"
                                                 }
                                             }
                                             // dnsSetup

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,8 @@ spec:
                 // See:
                 //  gcloud container get-server-config
                 def gkeKversions = ["1.11"]
-                for (kversion in gkeKversions) {
+                for (x in gkeKversions) {
+                    def kversion = x  // local bind required because closures
                     def project = 'bkprtesting'
                     def zone = 'us-east1-b'
                     def platform = "gke-" + kversion
@@ -383,7 +384,8 @@ spec:
                 // See:
                 //  az aks get-versions -l centralus --query 'sort(orchestrators[?orchestratorType==`Kubernetes`].orchestratorVersion)'
                 def aksKversions = ["1.10", "1.11"]
-                for (kversion in aksKversions) {
+                for (x in aksKversions) {
+                    def kversion = x  // local bind required because closures
                     def resourceGroup = 'jenkins-bkpr-rg'
                     def location = "eastus"
                     def platform = "aks-" + kversion
@@ -500,7 +502,8 @@ spec:
                 }
 
                 def eksKversions = ["1.10", "1.11"]
-                for (kversion in eksKversions) {
+                for (x in eksKversions) {
+                    def kversion = x  // local bind required because closures
                     def awsRegion = "us-east-1"
                     def awsUserPoolId = "${awsRegion}_zkRzdsjxA"
                     def awsZones = ["us-east-1b", "us-east-1f"]

--- a/tests/ingress_test.go
+++ b/tests/ingress_test.go
@@ -211,7 +211,7 @@ var _ = Describe("Ingress", func() {
 				}
 
 				return lbAddr, nil
-			}, "20m", "5s").
+			}, "5m", "5s").
 				ShouldNot(WithTransform(isPrivateIP, BeTrue()))
 		})
 
@@ -249,7 +249,7 @@ var _ = Describe("Ingress", func() {
 
 				resp, err = getURL(client, url)
 				return resp, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(statusCode, Equal(200)))
 
 			defer resp.Body.Close()
@@ -295,7 +295,7 @@ var _ = Describe("Ingress", func() {
 			Eventually(func() (*http.Response, error) {
 				resp, err = getURL(client, url)
 				return resp, err
-			}, "30m", "5s").
+			}, "10m", "5s").
 				Should(WithTransform(statusCode, Equal(200)))
 
 			defer resp.Body.Close()
@@ -336,7 +336,7 @@ var _ = Describe("Ingress", func() {
 					// NB: will follow redirects
 					resp, err = getURL(client, testUrl)
 					return resp, err
-				}, "20m", "5s").
+				}, "10m", "5s").
 					Should(WithTransform(statusCode, Or(Equal(200), Equal(400))))
 
 				fmt.Fprintf(GinkgoWriter, "Response:\n%#v", resp)
@@ -400,7 +400,7 @@ var _ = Describe("Ingress", func() {
 					// NB: will follow redirects
 					resp, err = getURL(client, testUrl)
 					return resp, err
-				}, "20m", "5s").
+				}, "10m", "5s").
 					Should(WithTransform(statusCode, Equal(200)))
 
 				fmt.Fprintf(GinkgoWriter, "Response:\n%#v", resp)

--- a/tests/logging_test.go
+++ b/tests/logging_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Logging", func() {
 				resp := apiResponse{}
 				json.Unmarshal(resultRaw, &resp)
 				return &resp, err
-			}, "15m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(totalHits, BeNumerically(">", 0)))
 		})
 	})

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -121,8 +121,9 @@ var _ = Describe("Exporters", func() {
 			}
 			fmt.Fprintf(GinkgoWriter, "}\n")
 		}
-
-		Expect(series).To(match)
+		Eventually(func() bool {
+			return Expect(series).To(match)
+		}, "2m", "5s").Should(BeTrue())
 	},
 		Entry("prometheus", `prometheus_tsdb_head_chunks{kubernetes_namespace="kubeprod",name="prometheus"}`, Not(BeEmpty())),
 		Entry("alertmanager", `alertmanager_peer_position`, Not(BeEmpty())),

--- a/tests/monitoring_test.go
+++ b/tests/monitoring_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &series)
 
 				return series, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countSeries, BeNumerically(">", 0)))
 
 			Expect(series[0].Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))
@@ -193,7 +193,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &managers)
 
 				return managers.Active, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countEndpoints, BeNumerically(">", 0)))
 
 			Expect(managers.Active[0].Url).To(ContainSubstring(am_path + "/api/v1/alerts"))
@@ -223,7 +223,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &series)
 
 				return series, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countSeries, BeNumerically(">", 0)))
 
 			Expect(series[0].Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))
@@ -247,7 +247,7 @@ var _ = Describe("Monitoring", func() {
 				json.Unmarshal(resp.Data, &alerts)
 
 				return alerts, err
-			}, "20m", "5s").
+			}, "5m", "5s").
 				Should(WithTransform(countAlerts, BeNumerically(">", 0)))
 
 			Expect(alerts[0].Label.Container).To(Equal(deploy.Spec.Template.Spec.Containers[0].Name))


### PR DESCRIPTION
Backported:
 b5859ca - tests: optimize retry timeouts
 705ec25 - tests: [fix] retry monitoring/exporters test
 a8d901e - ci: ignore cluster deletion errors for EKS
 d1fcdcb - ci: fix aks k8s version selection
 422d434 - tests: retry Exporters tests on failures