### PR TITLE
Update instructions to add application monitoring via Prometheus

### DIFF
--- a/docs/application-developers-reference-guide.md
+++ b/docs/application-developers-reference-guide.md
@@ -71,7 +71,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
     prometheus.io/port: "9104"
-    prometheus.io/metrics: "/metrics"
+    prometheus.io/path: "/metrics"
 spec:
   type: ClusterIP
   ports:


### PR DESCRIPTION
Signed-off-by: juan131 <juan@bitnami.com>

The annotations suggested to allow Prometheus collecting metrics from a service's endpoints are wrong since the `prometheus.io/metrics` annotation is not used to set the path. 

This PR sets the right annotation (`prometheus.io/path`) in the instructions.