### PR TITLE
ci: apply `status/waiting-for-review` to automated component update PRs

### DIFF
--- a/jenkins/automation/functions
+++ b/jenkins/automation/functions
@@ -174,7 +174,7 @@ create_pull_request() {
     done < MAINTAINERS
   fi
 
-  hub pull-request -b "${base_branch}" -m "${pr_title}" ${REVIEWERS:+-r "${REVIEWERS}"} >/dev/null
+  hub pull-request -l "status/waiting-for-review" -b "${base_branch}" -m "${pr_title}" ${REVIEWERS:+-r "${REVIEWERS}"} >/dev/null
 }
 
 # deletes a branch from the specified remote, as well as locally


### PR DESCRIPTION
The `status/waiting-for-review` label blocks the CI from building the PR's allowing
project maintainers to review the changes before they are picked up by the CI.