### PR TITLE
adding elasticsearch-curator

### DIFF
--- a/manifests/components/elasticsearch-curator.jsonnet
+++ b/manifests/components/elasticsearch-curator.jsonnet
@@ -17,17 +17,17 @@
  * limitations under the License.
  */
 
-local kube = import "../lib/kube.libsonnet";
-local utils = import "../lib/utils.libsonnet";
+local kube = import '../lib/kube.libsonnet';
+local utils = import '../lib/utils.libsonnet';
 
-local CURATOR_IMAGE = (import "images.json").curator;
+local CURATOR_IMAGE = (import 'images.json').curator;
 
 // Implement elasticsearch-curator as a Kubernetes CronJob
 local elasticsearch_curator = {
-  namespace:: null,
-  name:: "elasticsearch-curator",
+  namespace:: 'kubeprod',
+  name:: 'elasticsearch-curator',
   retention_days:: 60,
-  elasticsearch_host:: "elasticsearch-logging",
+  elasticsearch_host:: 'elasticsearch-logging',
   elasticsearch_port:: 9200,
   elasticsearch_curator_config: kube.ConfigMap($.name) {
     metadata+: {
@@ -87,8 +87,8 @@ local elasticsearch_curator = {
           logformat: default
           blacklist: ['elasticsearch', 'urllib3']
       |||,
-      "action_file.yml": std.format(self.action_file_yml_tmpl, [$.retention_days]),
-      "config.yml": std.format(self.config_yml_tmpl, [$.elasticsearch_host, $.elasticsearch_port]),
+      'action_file.yml': std.format(self.action_file_yml_tmpl, [$.retention_days]),
+      'config.yml': std.format(self.config_yml_tmpl, [$.elasticsearch_host, $.elasticsearch_port]),
     },
   },
   elasticsearch_curator_cronjob: kube.CronJob($.name) {
@@ -96,19 +96,19 @@ local elasticsearch_curator = {
       namespace: $.namespace,
     },
     spec+: {
-      schedule: "30 0 * * *",
+      schedule: '30 0 * * *',
       jobTemplate+: {
         spec+:
           {
             template+: {
               spec+: {
                 containers_+: {
-                  curator: kube.Container("curator") {
+                  curator: kube.Container('curator') {
                     image: CURATOR_IMAGE,
-                    args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"],
+                    args: ['--config', '/etc/config/config.yml', '/etc/config/action_file.yml'],
                     volumeMounts_+: {
                       config_vol: {
-                        mountPath: "/etc/config",
+                        mountPath: '/etc/config',
                         readOnly: true,
                       },
                     },

--- a/manifests/components/elasticsearch-curator.jsonnet
+++ b/manifests/components/elasticsearch-curator.jsonnet
@@ -1,0 +1,128 @@
+/*
+ * Bitnami Kubernetes Production Runtime - A collection of services that makes it
+ * easy to run production workloads in Kubernetes.
+ *
+ * Copyright 2018-2019 Bitnami
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+local kube = import "../lib/kube.libsonnet";
+local utils = import "../lib/utils.libsonnet";
+
+local CURATOR_IMAGE = (import "images.json").curator;
+
+// Implement elasticsearch-curator as a Kubernetes CronJob
+local elasticsearch_curator = {
+  namespace:: null,
+  name:: "elasticsearch-curator",
+  retention_days:: 60,
+  elasticsearch_host:: "elasticsearch-logging",
+  elasticsearch_port:: 9200,
+  elasticsearch_curator_config: kube.ConfigMap($.name) {
+    metadata+: {
+      namespace: $.namespace,
+    },
+    data+: {
+      action_file_yml_tmpl:: |||
+        ---
+        # Remember, leave a key empty if there is no value.  None will be a string,
+        # not a Python "NoneType"
+        #
+        # Also remember that all examples have 'disable_action' set to True.  If you
+        # want to use this action as a template, be sure to set this to False after
+        # copying it.
+        actions:
+          1:
+            action: delete_indices
+            description: "Clean up ES by deleting old indices"
+            options:
+              timeout_override:
+              continue_if_exception: False
+              disable_action: False
+              ignore_empty_list: True
+            filters:
+            - filtertype: age
+              source: name
+              direction: older
+              timestring: '%%Y.%%m.%%d'
+              unit: days
+              unit_count: %d
+              field:
+              stats_result:
+              epoch:
+              exclude: False
+      |||,
+      config_yml_tmpl:: |||
+        ---
+        # Remember, leave a key empty if there is no value.  None will be a string,
+        # not a Python "NoneType"
+        client:
+          hosts:
+            - %s
+          port: %d
+          url_prefix:
+          use_ssl: False
+          certificate:
+          client_cert:
+          client_key:
+          ssl_no_validate: False
+          http_auth:
+          timeout: 30
+          master_only: False
+
+        logging:
+          loglevel: INFO
+          logfile:
+          logformat: default
+          blacklist: ['elasticsearch', 'urllib3']
+      |||,
+      "action_file.yml": std.format(self.action_file_yml_tmpl, [$.retention_days]),
+      "config.yml": std.format(self.config_yml_tmpl, [$.elasticsearch_host, $.elasticsearch_port]),
+    },
+  },
+  elasticsearch_curator_cronjob: kube.CronJob($.name) {
+    metadata+: {
+      namespace: $.namespace,
+    },
+    spec+: {
+      schedule: "30 0 * * *",
+      jobTemplate+: {
+        spec+:
+          {
+            template+: {
+              spec+: {
+                containers_+: {
+                  curator: kube.Container("curator") {
+                    image: CURATOR_IMAGE,
+                    args: ["--config", "/etc/config/config.yml", "/etc/config/action_file.yml"],
+                    volumeMounts_+: {
+                      config_vol: {
+                        mountPath: "/etc/config",
+                        readOnly: true,
+                      },
+                    },
+                  },
+                },
+                volumes_+: {
+                  config_vol: kube.ConfigMapVolume($.elasticsearch_curator_config),
+                },
+              },
+            },
+          },
+      },
+    },
+  },
+};
+
+kube.List() { items_+: elasticsearch_curator }

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -20,7 +20,7 @@
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = (import "images.json").elasticsearch;
+local ELASTICSEARCH_IMAGE = (import "images.json")["elasticsearch"];
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
@@ -47,7 +47,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
     },
   },
 
-  metadata:: $.labels {
+  metadata:: $.labels + {
     metadata+: {
       namespace: "kubeprod",
     },
@@ -71,13 +71,13 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
     subjects_+: [$.serviceAccount],
   },
 
-  disruptionBudget: kube.PodDisruptionBudget($.p + "elasticsearch-logging") + $.metadata {
+  disruptionBudget: kube.PodDisruptionBudget($.p+"elasticsearch-logging") + $.metadata {
     target_pod: $.sts.spec.template,
     spec+: { maxUnavailable: 1 },
   },
 
   // ConfigMap for additional Java security properties
-  java_security: kube.ConfigMap($.p + "java-elasticsearch-logging") + $.metadata {
+  java_security: kube.ConfigMap($.p+"java-elasticsearch-logging") + $.metadata {
     data+: {
       "java.security": (importstr "elasticsearch-config/java.security"),
     },
@@ -117,7 +117,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
               resources: {
                 requests: { cpu: "100m", memory: "1200Mi" },
                 limits: {
-                  cpu: "1",  // uses lots of CPU when indexing
+                  cpu: "1", // uses lots of CPU when indexing
                   memory: "2Gi",
                 },
               },
@@ -146,7 +146,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 local heapsize = kube.siToNum(container.resources.requests.memory) / std.pow(2, 20),
                 ES_JAVA_OPTS: std.join(" ", [
                   "-Djava.security.properties=%s" % JAVA_SECURITY_MOUNTPOINT,
-                  "-Xms%dm" % heapsize,  // ES asserts that these are equal
+                  "-Xms%dm" % heapsize, // ES asserts that these are equal
                   "-Xmx%dm" % heapsize,
                   "-XshowSettings:vm",
                 ]),

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -17,86 +17,89 @@
  * limitations under the License.
  */
 
-local kube = import "../lib/kube.libsonnet";
-local utils = import "../lib/utils.libsonnet";
+local kube = import '../lib/kube.libsonnet';
+local utils = import '../lib/utils.libsonnet';
 
-local ELASTICSEARCH_IMAGE = (import "images.json")["elasticsearch"];
+local ELASTICSEARCH_IMAGE = (import 'images.json').elasticsearch;
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
-local ELASTICSEARCH_DATA_MOUNTPOINT = "/bitnami/elasticsearch/data";
+local ELASTICSEARCH_DATA_MOUNTPOINT = '/bitnami/elasticsearch/data';
 
 // Mount point for the custom Java security properties configuration file
-local JAVA_SECURITY_MOUNTPOINT = "/opt/bitnami/java/lib/security/java.security.custom";
+local JAVA_SECURITY_MOUNTPOINT = '/opt/bitnami/java/lib/security/java.security.custom';
+
+// Use elasticsearch curator to rotate indices
+local elasticsearch_curator = import 'elasticsearch-curator.jsonnet';
 
 local ELASTICSEARCH_HTTP_PORT = 9200;
 local ELASTICSEARCH_TRANSPORT_PORT = 9300;
 
 {
-  p:: "",
+  p:: '',
   min_master_nodes:: 2,
 
   labels:: {
     metadata+: {
       labels+: {
-        "k8s-app": "elasticsearch-logging",
+        'k8s-app': 'elasticsearch-logging',
       },
     },
   },
 
-  metadata:: $.labels + {
+  metadata:: $.labels {
     metadata+: {
-      namespace: "kubeprod",
+      namespace: 'kubeprod',
     },
   },
 
-  serviceAccount: kube.ServiceAccount($.p + "elasticsearch-logging") + $.metadata {
+  serviceAccount: kube.ServiceAccount($.p + 'elasticsearch-logging') + $.metadata {
   },
 
-  elasticsearchRole: kube.ClusterRole($.p + "elasticsearch-logging") + $.labels {
+  elasticsearchRole: kube.ClusterRole($.p + 'elasticsearch-logging') + $.labels {
     rules: [
       {
-        apiGroups: [""],
-        resources: ["services", "namespaces", "endpoints"],
-        verbs: ["get"],
+        apiGroups: [''],
+        resources: ['services', 'namespaces', 'endpoints'],
+        verbs: ['get'],
       },
     ],
   },
 
-  elasticsearchBinding: kube.ClusterRoleBinding($.p + "elasticsearch-logging") + $.labels {
+  elasticsearchBinding: kube.ClusterRoleBinding($.p + 'elasticsearch-logging') + $.labels {
     roleRef_: $.elasticsearchRole,
     subjects_+: [$.serviceAccount],
   },
 
-  disruptionBudget: kube.PodDisruptionBudget($.p+"elasticsearch-logging") + $.metadata {
+  disruptionBudget: kube.PodDisruptionBudget($.p + 'elasticsearch-logging') + $.metadata {
     target_pod: $.sts.spec.template,
     spec+: { maxUnavailable: 1 },
   },
 
   // ConfigMap for additional Java security properties
-  java_security: kube.ConfigMap($.p+"java-elasticsearch-logging") + $.metadata {
+  java_security: kube.ConfigMap($.p + 'java-elasticsearch-logging') + $.metadata {
     data+: {
-      "java.security": (importstr "elasticsearch-config/java.security"),
+      'java.security': (importstr 'elasticsearch-config/java.security'),
     },
   },
 
-  sts: kube.StatefulSet($.p + "elasticsearch-logging") + $.metadata {
+  sts: kube.StatefulSet($.p + 'elasticsearch-logging') + $.metadata {
     local this = self,
     spec+: {
-      podManagementPolicy: "Parallel",
+      podManagementPolicy: 'Parallel',
       replicas: 3,
-      updateStrategy: { type: "RollingUpdate" },
+      updateStrategy: { type: 'RollingUpdate' },
       template+: {
         metadata+: {
           annotations+: {
-            "prometheus.io/scrape": "true",
-            "prometheus.io/port": "9102",
+            'prometheus.io/scrape': 'true',
+            'prometheus.io/port': '9102',
           },
         },
         spec+: {
           serviceAccountName: $.serviceAccount.metadata.name,
           affinity: kube.PodZoneAntiAffinityAnnotation(this.spec.template),
-          default_container: "elasticsearch_logging",
+          default_container: 'elasticsearch_logging',
           volumes_+: {
             java_security: kube.ConfigMapVolume($.java_security),
           },
@@ -104,7 +107,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
             fsGroup: 1001,
           },
           containers_+: {
-            elasticsearch_logging: kube.Container("elasticsearch-logging") {
+            elasticsearch_logging: kube.Container('elasticsearch-logging') {
               local container = self,
               image: ELASTICSEARCH_IMAGE,
               // This can massively vary depending on the logging volume
@@ -112,10 +115,10 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 runAsUser: 1001,
               },
               resources: {
-                requests: { cpu: "100m", memory: "1200Mi" },
+                requests: { cpu: '100m', memory: '1200Mi' },
                 limits: {
-                  cpu: "1", // uses lots of CPU when indexing
-                  memory: "2Gi",
+                  cpu: '1',  // uses lots of CPU when indexing
+                  memory: '2Gi',
                 },
               },
               ports_+: {
@@ -127,29 +130,29 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 data: { mountPath: ELASTICSEARCH_DATA_MOUNTPOINT },
                 java_security: {
                   mountPath: JAVA_SECURITY_MOUNTPOINT,
-                  subPath: "java.security",
+                  subPath: 'java.security',
                   readOnly: true,
                 },
               },
               env_+: {
-                ELASTICSEARCH_CLUSTER_NAME: "elasticsearch-cluster",
+                ELASTICSEARCH_CLUSTER_NAME: 'elasticsearch-cluster',
                 // TODO: offer a dynamically sized pool of non-master nodes.
                 // Autoscaler will require custom HPA metrics in practice.
-                assert ($.sts.spec.replicas >= $.min_master_nodes && $.sts.spec.replicas < $.min_master_nodes * 2) : "Not enough quorum, verify min_master_nodes vs replicas",
+                assert ($.sts.spec.replicas >= $.min_master_nodes && $.sts.spec.replicas < $.min_master_nodes * 2) : 'Not enough quorum, verify min_master_nodes vs replicas',
                 ELASTICSEARCH_MINIMUM_MASTER_NODES: $.min_master_nodes,
                 ELASTICSEARCH_PORT_NUMBER: ELASTICSEARCH_HTTP_PORT,
                 ELASTICSEARCH_NODE_PORT_NUMBER: ELASTICSEARCH_TRANSPORT_PORT,
                 ELASTICSEARCH_CLUSTER_HOSTS: $.svc.metadata.name,
                 local heapsize = kube.siToNum(container.resources.requests.memory) / std.pow(2, 20),
-                ES_JAVA_OPTS: std.join(" ", [
-                  "-Djava.security.properties=%s" % JAVA_SECURITY_MOUNTPOINT,
-                  "-Xms%dm" % heapsize, // ES asserts that these are equal
-                  "-Xmx%dm" % heapsize,
-                  "-XshowSettings:vm",
+                ES_JAVA_OPTS: std.join(' ', [
+                  '-Djava.security.properties=%s' % JAVA_SECURITY_MOUNTPOINT,
+                  '-Xms%dm' % heapsize,  // ES asserts that these are equal
+                  '-Xmx%dm' % heapsize,
+                  '-XshowSettings:vm',
                 ]),
               },
               readinessProbe: {
-                httpGet: { path: "/_cluster/health?local=true", port: "db" },
+                httpGet: { path: '/_cluster/health?local=true', port: 'db' },
                 // don't allow rolling updates to kill containers until the cluster is green
                 // ...meaning it's not allocating replicas or relocating any shards
                 initialDelaySeconds: 120,
@@ -163,30 +166,30 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 successThreshold: 1,  // Minimum consecutive successes for the probe to be considered successful after having failed.
               },
             },
-            prom_exporter: kube.Container("prom-exporter") {
-              image: "justwatch/elasticsearch_exporter:1.0.1",
-              command: ["elasticsearch_exporter"],
+            prom_exporter: kube.Container('prom-exporter') {
+              image: 'justwatch/elasticsearch_exporter:1.0.1',
+              command: ['elasticsearch_exporter'],
               args_+: {
-                "es.uri": "http://localhost:%s/" % ELASTICSEARCH_HTTP_PORT,
-                "es.all": "false",
-                "es.timeout": "20s",
-                "web.listen-address": ":9102",
-                "web.telemetry-path": "/metrics",
+                'es.uri': 'http://localhost:%s/' % ELASTICSEARCH_HTTP_PORT,
+                'es.all': 'false',
+                'es.timeout': '20s',
+                'web.listen-address': ':9102',
+                'web.telemetry-path': '/metrics',
               },
               ports_+: {
                 metrics: { containerPort: 9102 },
               },
               livenessProbe: {
-                httpGet: { path: "/", port: "metrics" },
+                httpGet: { path: '/', port: 'metrics' },
               },
             },
           },
           initContainers_+: {
-            elasticsearch_logging_init: kube.Container("elasticsearch-logging-init") {
-              image: "alpine:3.6",
+            elasticsearch_logging_init: kube.Container('elasticsearch-logging-init') {
+              image: 'alpine:3.6',
               // TODO: investigate feasibility of switching to https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod
               // NOTE: copied verbatim from https://www.elastic.co/guide/en/elasticsearch/reference/5.6/vm-max-map-count.html
-              command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"],
+              command: ['/sbin/sysctl', '-w', 'vm.max_map_count=262144'],
               securityContext: {
                 privileged: true,
               },
@@ -197,16 +200,16 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
         },
       },
       volumeClaimTemplates_+: {
-        data: { storage: "100Gi" },
+        data: { storage: '100Gi' },
       },
     },
   },
 
-  svc: kube.Service($.p + "elasticsearch-logging") + $.metadata {
+  svc: kube.Service($.p + 'elasticsearch-logging') + $.metadata {
     target_pod: $.sts.spec.template,
     metadata+: {
       labels+: {
-        "kubernetes.io/name": "Elasticsearch",
+        'kubernetes.io/name': 'Elasticsearch',
       },
       annotations+: {
         // From: https://github.com/kubernetes/dns/blob/master/docs/specification.md
@@ -214,17 +217,18 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
         // of the EndpointSubset object, or the corresponding service has the following
         // annotation set to true.
         // NOTE: Deprecated in k8s 1.11
-        "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
+        'service.alpha.kubernetes.io/tolerate-unready-endpoints': 'true',
       },
     },
     spec+: {
-      clusterIP: "None",  // headless
+      clusterIP: 'None',  // headless
       // Publish endpoints resolved by the service even if they are not yet ready.
       // This allows ElasticSearch to discover IPv4 addresses for all nodes from
       // the StatefulSet for master discovery, even if they haven't come up and are
       // yet ready.
       publishNotReadyAddresses: true,
-      sessionAffinity: "None",
+      sessionAffinity: 'None',
     },
   },
+  curator: elasticsearch_curator,
 }

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -17,89 +17,89 @@
  * limitations under the License.
  */
 
-local kube = import '../lib/kube.libsonnet';
-local utils = import '../lib/utils.libsonnet';
+local kube = import "../lib/kube.libsonnet";
+local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = (import 'images.json').elasticsearch;
+local ELASTICSEARCH_IMAGE = (import "images.json").elasticsearch;
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
-local ELASTICSEARCH_DATA_MOUNTPOINT = '/bitnami/elasticsearch/data';
+local ELASTICSEARCH_DATA_MOUNTPOINT = "/bitnami/elasticsearch/data";
 
 // Mount point for the custom Java security properties configuration file
-local JAVA_SECURITY_MOUNTPOINT = '/opt/bitnami/java/lib/security/java.security.custom';
+local JAVA_SECURITY_MOUNTPOINT = "/opt/bitnami/java/lib/security/java.security.custom";
 
 // Use elasticsearch curator to rotate indices
-local elasticsearch_curator = import 'elasticsearch-curator.jsonnet';
+local elasticsearch_curator = import "elasticsearch-curator.jsonnet";
 
 local ELASTICSEARCH_HTTP_PORT = 9200;
 local ELASTICSEARCH_TRANSPORT_PORT = 9300;
 
 {
-  p:: '',
+  p:: "",
   min_master_nodes:: 2,
 
   labels:: {
     metadata+: {
       labels+: {
-        'k8s-app': 'elasticsearch-logging',
+        "k8s-app": "elasticsearch-logging",
       },
     },
   },
 
   metadata:: $.labels {
     metadata+: {
-      namespace: 'kubeprod',
+      namespace: "kubeprod",
     },
   },
 
-  serviceAccount: kube.ServiceAccount($.p + 'elasticsearch-logging') + $.metadata {
+  serviceAccount: kube.ServiceAccount($.p + "elasticsearch-logging") + $.metadata {
   },
 
-  elasticsearchRole: kube.ClusterRole($.p + 'elasticsearch-logging') + $.labels {
+  elasticsearchRole: kube.ClusterRole($.p + "elasticsearch-logging") + $.labels {
     rules: [
       {
-        apiGroups: [''],
-        resources: ['services', 'namespaces', 'endpoints'],
-        verbs: ['get'],
+        apiGroups: [""],
+        resources: ["services", "namespaces", "endpoints"],
+        verbs: ["get"],
       },
     ],
   },
 
-  elasticsearchBinding: kube.ClusterRoleBinding($.p + 'elasticsearch-logging') + $.labels {
+  elasticsearchBinding: kube.ClusterRoleBinding($.p + "elasticsearch-logging") + $.labels {
     roleRef_: $.elasticsearchRole,
     subjects_+: [$.serviceAccount],
   },
 
-  disruptionBudget: kube.PodDisruptionBudget($.p + 'elasticsearch-logging') + $.metadata {
+  disruptionBudget: kube.PodDisruptionBudget($.p + "elasticsearch-logging") + $.metadata {
     target_pod: $.sts.spec.template,
     spec+: { maxUnavailable: 1 },
   },
 
   // ConfigMap for additional Java security properties
-  java_security: kube.ConfigMap($.p + 'java-elasticsearch-logging') + $.metadata {
+  java_security: kube.ConfigMap($.p + "java-elasticsearch-logging") + $.metadata {
     data+: {
-      'java.security': (importstr 'elasticsearch-config/java.security'),
+      "java.security": (importstr "elasticsearch-config/java.security"),
     },
   },
 
-  sts: kube.StatefulSet($.p + 'elasticsearch-logging') + $.metadata {
+  sts: kube.StatefulSet($.p + "elasticsearch-logging") + $.metadata {
     local this = self,
     spec+: {
-      podManagementPolicy: 'Parallel',
+      podManagementPolicy: "Parallel",
       replicas: 3,
-      updateStrategy: { type: 'RollingUpdate' },
+      updateStrategy: { type: "RollingUpdate" },
       template+: {
         metadata+: {
           annotations+: {
-            'prometheus.io/scrape': 'true',
-            'prometheus.io/port': '9102',
+            "prometheus.io/scrape": "true",
+            "prometheus.io/port": "9102",
           },
         },
         spec+: {
           serviceAccountName: $.serviceAccount.metadata.name,
           affinity: kube.PodZoneAntiAffinityAnnotation(this.spec.template),
-          default_container: 'elasticsearch_logging',
+          default_container: "elasticsearch_logging",
           volumes_+: {
             java_security: kube.ConfigMapVolume($.java_security),
           },
@@ -107,7 +107,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
             fsGroup: 1001,
           },
           containers_+: {
-            elasticsearch_logging: kube.Container('elasticsearch-logging') {
+            elasticsearch_logging: kube.Container("elasticsearch-logging") {
               local container = self,
               image: ELASTICSEARCH_IMAGE,
               // This can massively vary depending on the logging volume
@@ -115,10 +115,10 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 runAsUser: 1001,
               },
               resources: {
-                requests: { cpu: '100m', memory: '1200Mi' },
+                requests: { cpu: "100m", memory: "1200Mi" },
                 limits: {
-                  cpu: '1',  // uses lots of CPU when indexing
-                  memory: '2Gi',
+                  cpu: "1",  // uses lots of CPU when indexing
+                  memory: "2Gi",
                 },
               },
               ports_+: {
@@ -130,29 +130,29 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 data: { mountPath: ELASTICSEARCH_DATA_MOUNTPOINT },
                 java_security: {
                   mountPath: JAVA_SECURITY_MOUNTPOINT,
-                  subPath: 'java.security',
+                  subPath: "java.security",
                   readOnly: true,
                 },
               },
               env_+: {
-                ELASTICSEARCH_CLUSTER_NAME: 'elasticsearch-cluster',
+                ELASTICSEARCH_CLUSTER_NAME: "elasticsearch-cluster",
                 // TODO: offer a dynamically sized pool of non-master nodes.
                 // Autoscaler will require custom HPA metrics in practice.
-                assert ($.sts.spec.replicas >= $.min_master_nodes && $.sts.spec.replicas < $.min_master_nodes * 2) : 'Not enough quorum, verify min_master_nodes vs replicas',
+                assert ($.sts.spec.replicas >= $.min_master_nodes && $.sts.spec.replicas < $.min_master_nodes * 2) : "Not enough quorum, verify min_master_nodes vs replicas",
                 ELASTICSEARCH_MINIMUM_MASTER_NODES: $.min_master_nodes,
                 ELASTICSEARCH_PORT_NUMBER: ELASTICSEARCH_HTTP_PORT,
                 ELASTICSEARCH_NODE_PORT_NUMBER: ELASTICSEARCH_TRANSPORT_PORT,
                 ELASTICSEARCH_CLUSTER_HOSTS: $.svc.metadata.name,
                 local heapsize = kube.siToNum(container.resources.requests.memory) / std.pow(2, 20),
-                ES_JAVA_OPTS: std.join(' ', [
-                  '-Djava.security.properties=%s' % JAVA_SECURITY_MOUNTPOINT,
-                  '-Xms%dm' % heapsize,  // ES asserts that these are equal
-                  '-Xmx%dm' % heapsize,
-                  '-XshowSettings:vm',
+                ES_JAVA_OPTS: std.join(" ", [
+                  "-Djava.security.properties=%s" % JAVA_SECURITY_MOUNTPOINT,
+                  "-Xms%dm" % heapsize,  // ES asserts that these are equal
+                  "-Xmx%dm" % heapsize,
+                  "-XshowSettings:vm",
                 ]),
               },
               readinessProbe: {
-                httpGet: { path: '/_cluster/health?local=true', port: 'db' },
+                httpGet: { path: "/_cluster/health?local=true", port: "db" },
                 // don't allow rolling updates to kill containers until the cluster is green
                 // ...meaning it's not allocating replicas or relocating any shards
                 initialDelaySeconds: 120,
@@ -166,30 +166,30 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 successThreshold: 1,  // Minimum consecutive successes for the probe to be considered successful after having failed.
               },
             },
-            prom_exporter: kube.Container('prom-exporter') {
-              image: 'justwatch/elasticsearch_exporter:1.0.1',
-              command: ['elasticsearch_exporter'],
+            prom_exporter: kube.Container("prom-exporter") {
+              image: "justwatch/elasticsearch_exporter:1.0.1",
+              command: ["elasticsearch_exporter"],
               args_+: {
-                'es.uri': 'http://localhost:%s/' % ELASTICSEARCH_HTTP_PORT,
-                'es.all': 'false',
-                'es.timeout': '20s',
-                'web.listen-address': ':9102',
-                'web.telemetry-path': '/metrics',
+                "es.uri": "http://localhost:%s/" % ELASTICSEARCH_HTTP_PORT,
+                "es.all": "false",
+                "es.timeout": "20s",
+                "web.listen-address": ":9102",
+                "web.telemetry-path": "/metrics",
               },
               ports_+: {
                 metrics: { containerPort: 9102 },
               },
               livenessProbe: {
-                httpGet: { path: '/', port: 'metrics' },
+                httpGet: { path: "/", port: "metrics" },
               },
             },
           },
           initContainers_+: {
-            elasticsearch_logging_init: kube.Container('elasticsearch-logging-init') {
-              image: 'alpine:3.6',
+            elasticsearch_logging_init: kube.Container("elasticsearch-logging-init") {
+              image: "alpine:3.6",
               // TODO: investigate feasibility of switching to https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod
               // NOTE: copied verbatim from https://www.elastic.co/guide/en/elasticsearch/reference/5.6/vm-max-map-count.html
-              command: ['/sbin/sysctl', '-w', 'vm.max_map_count=262144'],
+              command: ["/sbin/sysctl", "-w", "vm.max_map_count=262144"],
               securityContext: {
                 privileged: true,
               },
@@ -200,16 +200,16 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
         },
       },
       volumeClaimTemplates_+: {
-        data: { storage: '100Gi' },
+        data: { storage: "100Gi" },
       },
     },
   },
 
-  svc: kube.Service($.p + 'elasticsearch-logging') + $.metadata {
+  svc: kube.Service($.p + "elasticsearch-logging") + $.metadata {
     target_pod: $.sts.spec.template,
     metadata+: {
       labels+: {
-        'kubernetes.io/name': 'Elasticsearch',
+        "kubernetes.io/name": "Elasticsearch",
       },
       annotations+: {
         // From: https://github.com/kubernetes/dns/blob/master/docs/specification.md
@@ -217,17 +217,17 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
         // of the EndpointSubset object, or the corresponding service has the following
         // annotation set to true.
         // NOTE: Deprecated in k8s 1.11
-        'service.alpha.kubernetes.io/tolerate-unready-endpoints': 'true',
+        "service.alpha.kubernetes.io/tolerate-unready-endpoints": "true",
       },
     },
     spec+: {
-      clusterIP: 'None',  // headless
+      clusterIP: "None",  // headless
       // Publish endpoints resolved by the service even if they are not yet ready.
       // This allows ElasticSearch to discover IPv4 addresses for all nodes from
       // the StatefulSet for master discovery, even if they haven't come up and are
       // yet ready.
       publishNotReadyAddresses: true,
-      sessionAffinity: 'None',
+      sessionAffinity: "None",
     },
   },
   curator: elasticsearch_curator,

--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -9,5 +9,6 @@
     "kibana": "bitnami/kibana:6.7.2-r1",
     "nginx-ingress-controller": "bitnami/nginx-ingress-controller:0.24.1-r4",
     "oauth2_proxy": "bitnami/oauth2-proxy:3.1.0-r1",
+    "curator": "bobrik/curator:5.7.6",
     "prometheus": "bitnami/prometheus:2.9.2-r0"
 }

--- a/manifests/lib/kube.libsonnet
+++ b/manifests/lib/kube.libsonnet
@@ -429,6 +429,38 @@
     },
   },
 
+  CronJob(name): $._Object("batch/v1beta1", "CronJob", name) {
+    local cronjob = self,
+ 
+   spec: {
+      jobTemplate: {
+        spec: $.JobSpec {
+          template+: {
+            metadata+: {
+              labels: cronjob.metadata.labels,
+            },
+          },
+        },
+      },
+      schedule: error "Need to provide spec.schedule",
+      successfulJobsHistoryLimit: 10,
+      failedJobsHistoryLimit: 20,
+      concurrencyPolicy: "Forbid",
+    },
+  },
+
+  JobSpec: {
+    local this = self,
+
+    template: {
+      spec: $.PodSpec {
+        restartPolicy: "OnFailure",
+      },
+    },
+    completions: 1,
+    parallelism: 1,
+  },
+
   DaemonSet(name): $._Object("extensions/v1beta1", "DaemonSet", name) {
     local ds = self,
     spec: {


### PR DESCRIPTION
This  PR provides a cronjob (based on `bobrik/docker-curator` container),  which executed on a daily basis, takes care of removing all indices with more than `60` days old. 

