### PR TITLE
manifests: define grafana plugins array

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -431,6 +431,24 @@ custom_dashboards: kube.ConfigMap($.p + "grafana-custom-dashboards") + $.metadat
 
 And mount that ConfigMap in the desired location inside the Grafana pod.
 
+#### Grafana Plugins
+
+Plugins enables users to add support for various types of datasources, panels and apps to Grafana. Checkout the official [Plugin Repository](https://grafana.com/plugins) to discover the available plugins for Grafana.
+
+To install additional plug-ins, override the `plugins` item inside the `grafana` scope, like this:
+
+```jsonnet
+(import "../../manifests/platforms/aks.jsonnet") {
+    config:: import "kubeprod-autogen.json",
+    grafana+: {
+        plugins+: [
+            "grafana-piechart-panel",
+            "grafana-worldmap-panel",
+        ],
+    },
+}
+```
+
 ## Ingress stack
 ### NGINX Ingress Controller
 

--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -39,6 +39,9 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
   // Amount of persistent storage required by Alertmanager
   storage:: "1Gi",
 
+  // List of plugins to install
+  plugins:: [],
+
   prometheus:: error "No Prometheus service",
 
   // Default to "Admin". See http://docs.grafana.org/permissions/overview/ for
@@ -158,6 +161,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
                 GF_LOG_MODE: "console",
                 GF_LOG_LEVEL: "warn",
                 GF_METRICS_ENABLED: "true",
+                GF_INSTALL_PLUGINS: std.join(",", $.plugins),
               },
               ports_+: {
                 dashboard: { containerPort: 3000 },


### PR DESCRIPTION
the `plugins` array would allow users to easily install plugins to grafana using jsonnet overrides,
f.e. the following jsonnet overlay for grafana will install the listed plugins when applied

```
{
  plugins:: [
    "grafana-piechart-panel",
    "grafana-worldmap-panel",
  ],
}
```