### PR TITLE
[backports/1.2/manifests] backported changes to manifests

### DIFF
--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -38,6 +38,9 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
   // Amount of persistent storage required by Alertmanager
   storage:: "1Gi",
 
+  // List of plugins to install
+  plugins:: [],
+
   prometheus:: error "No Prometheus service",
 
   // Default to "Admin". See http://docs.grafana.org/permissions/overview/ for
@@ -122,6 +125,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
                 GF_LOG_MODE: "console",
                 GF_LOG_LEVEL: "warn",
                 GF_METRICS_ENABLED: "true",
+                GF_INSTALL_PLUGINS: std.join(",", $.plugins),
               },
               ports_+: {
                 dashboard: { containerPort: 3000 },

--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -72,7 +72,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
   },
 
   // Generates YAML configuration under provisioning/datasources/
-  datasources: kube.ConfigMap($.p + "grafana-prometheus-datasource") + $.metadata {
+  datasources: utils.HashedConfigMap($.p + "grafana-datasource-configuration") + $.metadata {
     local this = self,
     datasources:: {
       // Built-in datasource for BKPR's Prometheus


### PR DESCRIPTION
- manifests: reload grafana pods on ConfigMap updates
- manifests: define grafana plugins array