### PR TITLE
Enforce a jsonnet fmt style

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -327,8 +327,11 @@ spec:
                             stage('Manifests') {
                                 withGo() {
                                     dir("${env.WORKSPACE}/src/github.com/bitnami/kube-prod-runtime/manifests") {
-                                        withEnv(["PATH+KUBECFG=${tool 'kubecfg'}"]) {
-                                            sh 'make validate KUBECFG="kubecfg -v"'
+                                        withEnv([
+                                            "PATH+KUBECFG=${tool 'kubecfg'}",
+                                            "PATH+JSONNET=${tool 'jsonnet'}",
+                                        ]) {
+                                            sh 'make fmttest validate KUBECFG="kubecfg -v"'
                                         }
                                     }
                                 }

--- a/manifests/Makefile
+++ b/manifests/Makefile
@@ -1,4 +1,15 @@
 KUBECFG = kubecfg
+JSONNET_FMT = jsonnet fmt
+
+FMTFLAGS = \
+	--indent 2 \
+	--string-style d \
+	--comment-style s \
+	--no-pad-arrays \
+	--no-pad-objects \
+	--pretty-field-names \
+	--max-blank-lines 2 \
+	--sort-imports
 
 COMPONENTS := $(wildcard components/*.jsonnet)
 PLATFORMS := $(wildcard tests/*.jsonnet)
@@ -14,5 +25,18 @@ validate: $(PLATFORMS:%.jsonnet=%.jsonnet-validate)
 %.jsonnet-validate: %.jsonnet $(JFILES)
 	$(KUBECFG) validate --ignore-unknown $<
 
-.PHONY: all validate
-.PHONY: %.jsonnet-validate
+fmt: $(JFILES:%=%-fmt)
+fmttest: $(JFILES:%=%-fmttest)
+
+%-fmt: %
+	$(JSONNET_FMT) -i $(FMTFLAGS) -- $<
+
+%-fmttest: %
+	@echo "$(JSONNET_FMT) --test $(FMTFLAGS) $<"
+	@if ! $(JSONNET_FMT) --test $(FMTFLAGS) -- $<; then \
+	  echo "$< needs reformatting. Try: make -C manifests fmt" >&2; \
+	  exit 1; \
+	fi
+
+.PHONY: all validate fmt fmttest
+.PHONY: %.jsonnet-validate %-fmt %-fmttest

--- a/manifests/components/cert-manager.jsonnet
+++ b/manifests/components/cert-manager.jsonnet
@@ -31,8 +31,8 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
 
   // Letsencrypt environments
   letsencrypt_environments:: {
-    "prod": $.letsencryptProd.metadata.name,
-    "staging": $.letsencryptStaging.metadata.name,
+    prod: $.letsencryptProd.metadata.name,
+    staging: $.letsencryptStaging.metadata.name,
   },
   // Letsencrypt environment (defaults to the production one)
   letsencrypt_environment:: "prod",
@@ -52,7 +52,7 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
     spec+: {
       additionalPrinterColumns+: [
         {
-          JSONPath: ".status.conditions[?(@.type==\"Ready\")].status",
+          JSONPath: '.status.conditions[?(@.type=="Ready")].status',
           name: "Ready",
           type: "string",
         },
@@ -68,7 +68,7 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
           type: "string",
         },
         {
-          JSONPath: ".status.conditions[?(@.type==\"Ready\")].message",
+          JSONPath: '.status.conditions[?(@.type=="Ready")].message',
           name: "Status",
           priority: 1,
           type: "string",
@@ -160,7 +160,7 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
           type: "date",
         },
       ],
-    }
+    },
   },
 
   clusterissuerCRD: kube.CustomResourceDefinition("certmanager.k8s.io", "v1alpha1", "ClusterIssuer") {
@@ -205,12 +205,12 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
     ],
   },
 
-  clusterRoleBinding: kube.ClusterRoleBinding($.p+"cert-manager") {
+  clusterRoleBinding: kube.ClusterRoleBinding($.p + "cert-manager") {
     roleRef_: $.clusterRole,
     subjects_+: [$.sa],
   },
 
-  deploy: kube.Deployment($.p+"cert-manager") + $.metadata {
+  deploy: kube.Deployment($.p + "cert-manager") + $.metadata {
     spec+: {
       template+: {
         metadata+: {
@@ -247,7 +247,7 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
     },
   },
 
-  letsencryptStaging: $.ClusterIssuer($.p+"letsencrypt-staging") {
+  letsencryptStaging: $.ClusterIssuer($.p + "letsencrypt-staging") {
     local this = self,
     spec+: {
       acme+: {
@@ -260,7 +260,7 @@ local CERT_MANAGER_IMAGE = (import "images.json")["cert-manager"];
   },
 
   letsencryptProd: $.letsencryptStaging {
-    metadata+: {name: $.p+"letsencrypt-prod"},
+    metadata+: {name: $.p + "letsencrypt-prod"},
     spec+: {
       acme+: {
         server: "https://acme-v02.api.letsencrypt.org/directory",

--- a/manifests/components/elasticsearch.jsonnet
+++ b/manifests/components/elasticsearch.jsonnet
@@ -20,7 +20,7 @@
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
 
-local ELASTICSEARCH_IMAGE = (import "images.json")["elasticsearch"];
+local ELASTICSEARCH_IMAGE = (import "images.json").elasticsearch;
 
 // Mount point for the data volume (used by multiple containers, like the
 // elasticsearch container and the elasticsearch-fs init container)
@@ -44,7 +44,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
     },
   },
 
-  metadata:: $.labels + {
+  metadata:: $.labels {
     metadata+: {
       namespace: "kubeprod",
     },
@@ -68,13 +68,13 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
     subjects_+: [$.serviceAccount],
   },
 
-  disruptionBudget: kube.PodDisruptionBudget($.p+"elasticsearch-logging") + $.metadata {
+  disruptionBudget: kube.PodDisruptionBudget($.p + "elasticsearch-logging") + $.metadata {
     target_pod: $.sts.spec.template,
-    spec+: { maxUnavailable: 1 },
+    spec+: {maxUnavailable: 1},
   },
 
   // ConfigMap for additional Java security properties
-  java_security: kube.ConfigMap($.p+"java-elasticsearch-logging") + $.metadata {
+  java_security: kube.ConfigMap($.p + "java-elasticsearch-logging") + $.metadata {
     data+: {
       "java.security": (importstr "elasticsearch-config/java.security"),
     },
@@ -85,7 +85,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
     spec+: {
       podManagementPolicy: "Parallel",
       replicas: 3,
-      updateStrategy: { type: "RollingUpdate" },
+      updateStrategy: {type: "RollingUpdate"},
       template+: {
         metadata+: {
           annotations+: {
@@ -112,19 +112,19 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 runAsUser: 1001,
               },
               resources: {
-                requests: { cpu: "100m", memory: "1200Mi" },
+                requests: {cpu: "100m", memory: "1200Mi"},
                 limits: {
-                  cpu: "1", // uses lots of CPU when indexing
+                  cpu: "1",  // uses lots of CPU when indexing
                   memory: "2Gi",
                 },
               },
               ports_+: {
-                db: { containerPort: ELASTICSEARCH_HTTP_PORT },
-                transport: { containerPort: ELASTICSEARCH_TRANSPORT_PORT },
+                db: {containerPort: ELASTICSEARCH_HTTP_PORT},
+                transport: {containerPort: ELASTICSEARCH_TRANSPORT_PORT},
               },
               volumeMounts_+: {
                 // Persistence for ElasticSearch data
-                data: { mountPath: ELASTICSEARCH_DATA_MOUNTPOINT },
+                data: {mountPath: ELASTICSEARCH_DATA_MOUNTPOINT},
                 java_security: {
                   mountPath: JAVA_SECURITY_MOUNTPOINT,
                   subPath: "java.security",
@@ -143,13 +143,13 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 local heapsize = kube.siToNum(container.resources.requests.memory) / std.pow(2, 20),
                 ES_JAVA_OPTS: std.join(" ", [
                   "-Djava.security.properties=%s" % JAVA_SECURITY_MOUNTPOINT,
-                  "-Xms%dm" % heapsize, // ES asserts that these are equal
+                  "-Xms%dm" % heapsize,  // ES asserts that these are equal
                   "-Xmx%dm" % heapsize,
                   "-XshowSettings:vm",
                 ]),
               },
               readinessProbe: {
-                httpGet: { path: "/_cluster/health?local=true", port: "db" },
+                httpGet: {path: "/_cluster/health?local=true", port: "db"},
                 // don't allow rolling updates to kill containers until the cluster is green
                 // ...meaning it's not allocating replicas or relocating any shards
                 initialDelaySeconds: 120,
@@ -174,10 +174,10 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
                 "web.telemetry-path": "/metrics",
               },
               ports_+: {
-                metrics: { containerPort: 9102 },
+                metrics: {containerPort: 9102},
               },
               livenessProbe: {
-                httpGet: { path: "/", port: "metrics" },
+                httpGet: {path: "/", port: "metrics"},
               },
             },
           },
@@ -197,7 +197,7 @@ local ELASTICSEARCH_TRANSPORT_PORT = 9300;
         },
       },
       volumeClaimTemplates_+: {
-        data: { storage: "100Gi" },
+        data: {storage: "100Gi"},
       },
     },
   },

--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -38,7 +38,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
       {
         apiGroups: [""],
         resources: ["pods"],
-        verbs: ["get","watch","list"],
+        verbs: ["get", "watch", "list"],
       },
       {
         apiGroups: ["extensions"],
@@ -48,7 +48,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
       {
         apiGroups: [""],
         resources: ["nodes"],
-        verbs: ["get","watch","list"],
+        verbs: ["get", "watch", "list"],
       },
     ],
   },

--- a/manifests/components/fluentd-es.jsonnet
+++ b/manifests/components/fluentd-es.jsonnet
@@ -18,10 +18,10 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
+local kubecfg = import "kubecfg.libsonnet";
 
-local FLUENTD_ES_IMAGE = (import "images.json")["fluentd"];
+local FLUENTD_ES_IMAGE = (import "images.json").fluentd;
 local FLUENTD_ES_CONF_PATH = "/opt/bitnami/fluentd/conf";
 local FLUENTD_ES_CONFIGD_PATH = "/opt/bitnami/fluentd/conf/config.d";
 local FLUENTD_ES_LOG_FILE = "/opt/bitnami/fluentd/logs/fluentd.log";
@@ -36,7 +36,7 @@ local FLUENTD_ES_LOG_BUFFERS_PATH = "/var/log/fluentd-buffers";
     },
   },
 
-  criticalPod:: { metadata+: { annotations+: { "scheduler.alpha.kubernetes.io/critical-pod": "" } } },
+  criticalPod:: {metadata+: {annotations+: {"scheduler.alpha.kubernetes.io/critical-pod": ""}}},
 
   es: error "elasticsearch is required",
 
@@ -84,7 +84,7 @@ local FLUENTD_ES_LOG_BUFFERS_PATH = "/var/log/fluentd-buffers";
             "prometheus.io/scrape": "true",
             "prometheus.io/port": "24231",
             "prometheus.io/path": "/metrics",
-          }
+          },
         },
         spec+: {
           containers_+: {
@@ -98,16 +98,16 @@ local FLUENTD_ES_LOG_BUFFERS_PATH = "/var/log/fluentd-buffers";
                 ES_HOST: $.es.svc.host,
               },
               resources: {
-                requests: { cpu: "100m", memory: "200Mi" },
-                limits: { memory: "500Mi" },
+                requests: {cpu: "100m", memory: "200Mi"},
+                limits: {memory: "500Mi"},
               },
               volumeMounts_+: {
                 varlog: {
                   mountPath: "/var/log",
                   readOnly: true,
                 },
-                varlogpos: { mountPath: FLUENTD_ES_LOG_POS_PATH },
-                varlogbuffers: { mountPath: FLUENTD_ES_LOG_BUFFERS_PATH },
+                varlogpos: {mountPath: FLUENTD_ES_LOG_POS_PATH},
+                varlogbuffers: {mountPath: FLUENTD_ES_LOG_BUFFERS_PATH},
                 varlibdockercontainers: {
                   mountPath: "/var/lib/docker/containers",
                   readOnly: true,

--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -18,10 +18,10 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
+local kubecfg = import "kubecfg.libsonnet";
 
-local GRAFANA_IMAGE = (import "images.json")["grafana"];
+local GRAFANA_IMAGE = (import "images.json").grafana;
 local GRAFANA_DATASOURCES_CONFIG = "/opt/bitnami/grafana/conf/provisioning/datasources";
 local GRAFANA_DASHBOARDS_CONFIG = "/opt/bitnami/grafana/conf/provisioning/dashboards";
 local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
@@ -67,7 +67,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
           host: this.host,
           http: {
             paths: [
-              { path: "/", backend: $.svc.name_port },
+              {path: "/", backend: $.svc.name_port},
             ],
           },
         },
@@ -101,7 +101,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
     local this = self,
     dashboard_provider:: {
       // Grafana dashboards configuration
-      "kubernetes": {
+      kubernetes: {
         folder: "Kubernetes",
         type: "file",
         disableDeletion: false,
@@ -142,7 +142,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
             grafana: kube.Container("grafana") {
               image: GRAFANA_IMAGE,
               resources: {
-                limits: { cpu: "100m", memory: "100Mi" },
+                limits: {cpu: "100m", memory: "100Mi"},
                 requests: self.limits,
               },
               env_+: {
@@ -164,10 +164,10 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
                 GF_INSTALL_PLUGINS: std.join(",", $.plugins),
               },
               ports_+: {
-                dashboard: { containerPort: 3000 },
+                dashboard: {containerPort: 3000},
               },
               volumeMounts_+: {
-                datadir: { mountPath: GRAFANA_DATA_MOUNTPOINT },
+                datadir: {mountPath: GRAFANA_DATA_MOUNTPOINT},
                 datasources: {
                   mountPath: utils.path_join(GRAFANA_DATASOURCES_CONFIG, "bkpr.yml"),
                   subPath: "bkpr.yml",
@@ -188,7 +188,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
                 successThreshold: 1,
               },
               readinessProbe: {
-                tcpSocket: { port: "dashboard" },
+                tcpSocket: {port: "dashboard"},
                 successThreshold: 2,
                 initialDelaySeconds: 30,
               },

--- a/manifests/components/kibana.jsonnet
+++ b/manifests/components/kibana.jsonnet
@@ -18,10 +18,10 @@
  */
 
 local kube = import "../lib/kube.libsonnet";
-local kubecfg = import "kubecfg.libsonnet";
 local utils = import "../lib/utils.libsonnet";
+local kubecfg = import "kubecfg.libsonnet";
 
-local KIBANA_IMAGE = (import "images.json")["kibana"];
+local KIBANA_IMAGE = (import "images.json").kibana;
 local KIBANA_PLUGINS_PATH = "/opt/bitnami/kibana/plugins";
 
 local strip_trailing_slash(s) = (
@@ -89,7 +89,7 @@ local strip_trailing_slash(s) = (
                   join -v1 -t, -j1 -o1.2 /tmp/wanted.list /tmp/installed.list | while read url; do
                     ${url:+/opt/bitnami/kibana/bin/kibana-plugin install --no-optimize "$url"}
                   done
-                ||| % std.escapeStringBash(wanted)
+                ||| % std.escapeStringBash(wanted),
               ],
               volumeMounts_+: {
                 // Persistence for Kibana plugins
@@ -110,7 +110,7 @@ local strip_trailing_slash(s) = (
                   cpu: "10m",
                 },
                 limits: {
-                  cpu: "1000m", // initial startup requires lots of cpu
+                  cpu: "1000m",  // initial startup requires lots of cpu
                 },
               },
               env_+: {
@@ -121,7 +121,7 @@ local strip_trailing_slash(s) = (
                 XPACK_SECURITY_ENABLED: "false",
               },
               ports_+: {
-                ui: { containerPort: 5601 },
+                ui: {containerPort: 5601},
               },
               volumeMounts_+: {
                 // Persistence for Kibana plugins
@@ -150,7 +150,7 @@ local strip_trailing_slash(s) = (
           host: this.host,
           http: {
             paths: [
-              { path: this.kibanaPath, backend: $.svc.name_port },
+              {path: this.kibanaPath, backend: $.svc.name_port},
             ],
           },
         },

--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -35,7 +35,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
       "proxy-connect-timeout": "15",
       "disable-ipv6": "false",
 
-      "hsts": "true",
+      hsts: "true",
       //"hsts-include-subdomains": "false",
 
       "enable-vts-status": "true",
@@ -52,7 +52,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
   udpconf: kube.ConfigMap($.p + "udp-services") + $.metadata {
   },
 
-  ingressControllerClusterRole: kube.ClusterRole($.p+"nginx-ingress-controller") {
+  ingressControllerClusterRole: kube.ClusterRole($.p + "nginx-ingress-controller") {
     rules: [
       {
         apiGroups: [""],
@@ -110,12 +110,12 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
       {
         apiGroups: [""],
         resources: ["endpoints"],
-        verbs: ["get"], // ["create", "update"],
+        verbs: ["get"],  // ["create", "update"],
       },
     ],
   },
 
-  ingressControllerClusterRoleBinding: kube.ClusterRoleBinding($.p+"nginx-ingress-controller") {
+  ingressControllerClusterRoleBinding: kube.ClusterRoleBinding($.p + "nginx-ingress-controller") {
     roleRef_: $.ingressControllerClusterRole,
     subjects_: [$.serviceAccount],
   },
@@ -136,7 +136,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
         {name: "https", port: 443, protocol: "TCP"},
       ],
       type: "LoadBalancer",
-      externalTrafficPolicy: "Local", // preserve source IP (where supported)
+      externalTrafficPolicy: "Local",  // preserve source IP (where supported)
     },
   },
 
@@ -165,7 +165,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
             "prometheus.io/scrape": "true",
             "prometheus.io/port": "10254",
             "prometheus.io/path": "/metrics",
-          }
+          },
         },
         spec+: {
           serviceAccountName: $.serviceAccount.metadata.name,

--- a/manifests/components/oauth2-proxy.jsonnet
+++ b/manifests/components/oauth2-proxy.jsonnet
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-local kubecfg = import "kubecfg.libsonnet";
 local kube = import "../lib/kube.libsonnet";
 local utils = import "../lib/utils.libsonnet";
+local kubecfg = import "kubecfg.libsonnet";
 
-local OAUTH2_PROXY_IMAGE = (import "images.json")["oauth2_proxy"];
+local OAUTH2_PROXY_IMAGE = (import "images.json").oauth2_proxy;
 
 {
   p:: "",
@@ -81,9 +81,9 @@ local OAUTH2_PROXY_IMAGE = (import "images.json")["oauth2_proxy"];
         host: this.host,
         http: {
           paths: [
-            { path: "/oauth2/", backend: $.svc.name_port },
+            {path: "/oauth2/", backend: $.svc.name_port},
             // The "/" block is only used for the location regex rewrite
-            { path: "/", backend: $.svc.name_port },
+            {path: "/", backend: $.svc.name_port},
           ],
         },
       }],
@@ -108,7 +108,7 @@ local OAUTH2_PROXY_IMAGE = (import "images.json")["oauth2_proxy"];
                 "cookie-refresh": "3h",
                 "set-xauthrequest": true,
                 "tls-cert": "",
-                "upstream": "file:///dev/null",
+                upstream: "file:///dev/null",
                 "redirect-url": "https://%s/oauth2/callback" % $.ingress.host,
                 "cookie-domain": utils.parentDomain($.ingress.host),
               },

--- a/manifests/components/prometheus-config.jsonnet
+++ b/manifests/components/prometheus-config.jsonnet
@@ -36,9 +36,9 @@ local NODE_NAME = "__meta_kubernetes_node_name";
 
 {
   global: {
-    scrape_interval_secs:: 60, // default
+    scrape_interval_secs:: 60,  // default
     scrape_interval: "%ds" % self.scrape_interval_secs,
-    evaluation_interval: "60s", // default
+    evaluation_interval: "60s",  // default
   },
 
   alerting: {
@@ -336,6 +336,8 @@ local NODE_NAME = "__meta_kubernetes_node_name";
       ],
     },
   },
-  scrape_configs: [{job_name: k} + self.scrape_configs_[k]
-                   for k in std.objectFields(self.scrape_configs_)],
+  scrape_configs: [
+    {job_name: k} + self.scrape_configs_[k]
+    for k in std.objectFields(self.scrape_configs_)
+  ],
 }

--- a/manifests/components/version.jsonnet
+++ b/manifests/components/version.jsonnet
@@ -21,9 +21,9 @@ local kube = import "../lib/kube.libsonnet";
 
 local trim = function(str) (
   if std.startsWith(str, " ") || std.startsWith(str, "\n") then
-  trim(std.substr(str, 1, std.length(str) - 1))
+    trim(std.substr(str, 1, std.length(str) - 1))
   else if std.endsWith(str, " ") || std.endsWith(str, "\n") then
-  trim(std.substr(str, 0, std.length(str) - 1))
+    trim(std.substr(str, 0, std.length(str) - 1))
   else
     str
 );

--- a/manifests/lib/utils.libsonnet
+++ b/manifests/lib/utils.libsonnet
@@ -41,7 +41,7 @@ local kube = import "kube.libsonnet";
 
   parentDomain(fqdn):: (
     local parts = std.split(fqdn, ".");
-    local tail = [parts[i] for i in std.range(1, std.length(parts)-1)];
+    local tail = [parts[i] for i in std.range(1, std.length(parts) - 1)];
     assert std.length(tail) >= 1 : "Tried to use parent of top-level DNS domain %s" % fqdn;
     std.join(".", tail)
   ),

--- a/manifests/tests/aks.jsonnet
+++ b/manifests/tests/aks.jsonnet
@@ -20,7 +20,7 @@
 // Test AKS
 
 (import "../platforms/aks.jsonnet") {
-  "letsencrypt_contact_email": "noone@nowhere.com",
+  letsencrypt_contact_email: "noone@nowhere.com",
   config: {
     dnsZone: "test.example.com",
     externalDns: {

--- a/manifests/tests/eks.jsonnet
+++ b/manifests/tests/eks.jsonnet
@@ -20,7 +20,7 @@
 // Test EKS
 
 (import "../platforms/eks.jsonnet") {
-  "letsencrypt_contact_email": "noone@nowhere.com",
+  letsencrypt_contact_email: "noone@nowhere.com",
   config: {
     dnsZone: "test.example.com",
     externalDns: {

--- a/manifests/tests/gke.jsonnet
+++ b/manifests/tests/gke.jsonnet
@@ -20,7 +20,7 @@
 // Test GKE
 
 (import "../platforms/gke.jsonnet") {
-  "letsencrypt_contact_email": "noone@nowhere.com",
+  letsencrypt_contact_email: "noone@nowhere.com",
   config: {
     dnsZone: "test.example.com",
     externalDns: {


### PR DESCRIPTION
Add `Makefile` support for running and enforcing `jsonnet fmt` style
against our jsonnet files.

`make -C manifests fmttest` does a read-only verification.  This is
now called from `Jenkinsfile` to enforce style compliance.

`make -C manifests fmt` will update files in-place to follow the style
guide.

Fwiw, the current change (and jenkins config) will use `jsonnet`
0.12.1.  There have been minor `fmt` style deviations over the history
of `jsonnet`.