### PR TITLE
Revert "grafana: component image updated to 'bitnami/grafana:6.2.0-r0'"

### DIFF
--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -5,7 +5,7 @@
     "elasticsearch": "bitnami/elasticsearch:6.7.1-r2",
     "external-dns": "bitnami/external-dns:0.5.14-r0",
     "fluentd": "bitnami/fluentd:1.5.0-r1",
-    "grafana": "bitnami/grafana:6.2.0-r0",
+    "grafana": "bitnami/grafana:6.1.6-r3",
     "kibana": "bitnami/kibana:6.7.2-r1",
     "nginx-ingress-controller": "bitnami/nginx-ingress-controller:0.24.1-r4",
     "oauth2_proxy": "bitnami/oauth2-proxy:3.1.0-r1",


### PR DESCRIPTION
This reverts commit ec3d08f6e09516106db49a770dbe53d65531c7ab.

I have observed issues server issues reported in the dashboards after
this update. Temporarily reverting until this issue can be investigated
and fixed