### PR TITLE
base kubeprod docker image on bitnami/minideb:stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM bitnami/minideb:stretch
 
 LABEL maintainer "Bitnami <containers@bitnami.com>"
 
@@ -6,14 +6,13 @@ ARG BKPR_VERSION
 
 RUN : "${BKPR_VERSION:?BKPR_VERSION build argument not specified}"
 
-RUN apk add --update ca-certificates \
+RUN install_packages wget ca-certificates \
  && mkdir -p "/usr/lib/bkpr/" \
  && wget "https://github.com/bitnami/kube-prod-runtime/releases/download/${BKPR_VERSION}/bkpr-${BKPR_VERSION}-linux-amd64.tar.gz" \
  && tar -zxf "bkpr-${BKPR_VERSION}-linux-amd64.tar.gz" -C "/usr/bin/" "bkpr-${BKPR_VERSION}/kubeprod" --strip 1 \
  && tar -zxf "bkpr-${BKPR_VERSION}-linux-amd64.tar.gz" -C "/usr/lib/bkpr/" "bkpr-${BKPR_VERSION}/manifests" --strip 1 \
  && chmod +x "/usr/bin/kubeprod" \
- && rm -rf "bkpr-${BKPR_VERSION}-linux-amd64.tar.gz" \
- && rm /var/cache/apk/*
+ && rm -rf "bkpr-${BKPR_VERSION}-linux-amd64.tar.gz"
 
 WORKDIR /bkpr
 


### PR DESCRIPTION
(cherry picked from commit 22d92dddc18857e089f618242cdfbd1e4aea386d)