### PR TITLE
[backports/release-1.3] backport ci updates

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -246,6 +246,9 @@ spec:
     tty: true
     command:
     - 'cat'
+    securityContext:
+      runAsUser: 0
+      fsGroup: 0
   - name: 'kaniko'
     image: 'gcr.io/kaniko-project/executor:debug-v0.9.0'
     tty: true


### PR DESCRIPTION
ci: set securityContext of kubectl container to root

(cherry picked from commit 2cf43d5a21ebdd0fef30c9ec571f8f0f4a95425b)