### PR TITLE
kube-state-metrics doesn't work in recent Kubernetes versions

### DIFF
--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -438,21 +438,21 @@ local get_cm_web_hook_url = function(port, path) (
   ksm: {
     serviceAccount: kube.ServiceAccount($.p + "kube-state-metrics") + $.metadata {
     },
-    
-    clusterRole+: kube.ClusterRole($.p + 'kube-state-metrics') {
-		local core = '',  // workaround empty-string-key bug in `jsonnet fmt`
-		local listwatch = {
-		  [core]: ['nodes', 'pods', 'services', 'resourcequotas', 'replicationcontrollers', 'limitranges', 'persistentvolumeclaims', 'namespaces'],
-		  apps: ['statefulsets', 'daemonsets', 'deployments', 'replicasets'],
-		  batch: ['cronjobs', 'jobs'],
-		},
-		all_resources:: std.set(std.flattenArrays(kube.objectValues(listwatch))),
-		rules: [{
-		  apiGroups: [k],
-		  resources: listwatch[k],
-		  verbs: ['list', 'watch'],
-		} for k in std.objectFields(listwatch)],
-	  },
+
+    clusterRole+: kube.ClusterRole($.p + "kube-state-metrics") {
+      local core = "",  // workaround empty-string-key bug in `jsonnet fmt`
+      local listwatch = {
+        [core]: ["nodes", "pods", "services", "resourcequotas", "replicationcontrollers", "limitranges", "persistentvolumeclaims", "namespaces"],
+        apps: ["statefulsets", "daemonsets", "deployments", "replicasets"],
+        batch: ["cronjobs", "jobs"],
+      },
+      all_resources:: std.set(std.flattenArrays(kube.objectValues(listwatch))),
+      rules: [{
+        apiGroups: [k],
+        resources: listwatch[k],
+        verbs: ["list", "watch"],
+      } for k in std.objectFields(listwatch)],
+    },
 
     clusterRoleBinding: kube.ClusterRoleBinding($.p + "kube-state-metrics") {
       roleRef_: $.ksm.clusterRole,

--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -439,7 +439,7 @@ local get_cm_web_hook_url = function(port, path) (
     serviceAccount: kube.ServiceAccount($.p + "kube-state-metrics") + $.metadata {
     },
 
-    clusterRole+: kube.ClusterRole($.p + "kube-state-metrics") {
+    clusterRole: kube.ClusterRole($.p + "kube-state-metrics") {
       local core = "",  // workaround empty-string-key bug in `jsonnet fmt`
       local listwatch = {
         [core]: ["nodes", "pods", "services", "resourcequotas", "replicationcontrollers", "limitranges", "persistentvolumeclaims", "namespaces"],

--- a/manifests/components/prometheus.jsonnet
+++ b/manifests/components/prometheus.jsonnet
@@ -438,22 +438,21 @@ local get_cm_web_hook_url = function(port, path) (
   ksm: {
     serviceAccount: kube.ServiceAccount($.p + "kube-state-metrics") + $.metadata {
     },
-
-    clusterRole: kube.ClusterRole($.p + "kube-state-metrics") {
-      local core = "",  // workaround empty-string-key bug in `jsonnet fmt`
-      local listwatch = {
-        [core]: ["nodes", "pods", "services", "resourcequotas", "replicationcontrollers", "limitranges", "persistentvolumeclaims", "namespaces"],
-        extensions: ["daemonsets", "deployments", "replicasets"],
-        apps: ["statefulsets"],
-        batch: ["cronjobs", "jobs"],
-      },
-      all_resources:: std.set(std.flattenArrays(kube.objectValues(listwatch))),
-      rules: [{
-        apiGroups: [k],
-        resources: listwatch[k],
-        verbs: ["list", "watch"],
-      } for k in std.objectFields(listwatch)],
-    },
+    
+    clusterRole+: kube.ClusterRole($.p + 'kube-state-metrics') {
+		local core = '',  // workaround empty-string-key bug in `jsonnet fmt`
+		local listwatch = {
+		  [core]: ['nodes', 'pods', 'services', 'resourcequotas', 'replicationcontrollers', 'limitranges', 'persistentvolumeclaims', 'namespaces'],
+		  apps: ['statefulsets', 'daemonsets', 'deployments', 'replicasets'],
+		  batch: ['cronjobs', 'jobs'],
+		},
+		all_resources:: std.set(std.flattenArrays(kube.objectValues(listwatch))),
+		rules: [{
+		  apiGroups: [k],
+		  resources: listwatch[k],
+		  verbs: ['list', 'watch'],
+		} for k in std.objectFields(listwatch)],
+	  },
 
     clusterRoleBinding: kube.ClusterRoleBinding($.p + "kube-state-metrics") {
       roleRef_: $.ksm.clusterRole,
@@ -496,7 +495,7 @@ local get_cm_web_hook_url = function(port, path) (
             serviceAccountName: $.ksm.serviceAccount.metadata.name,
             containers_+: {
               default+: kube.Container("ksm") {
-                image: "quay.io/coreos/kube-state-metrics:v1.1.0",
+                image: "quay.io/coreos/kube-state-metrics:v1.8.0",
                 ports_: {
                   metrics: {containerPort: 8080},
                 },


### PR DESCRIPTION
Fix #655 
Due to the same API deprecations/changes reported [here](https://www.ibm.com/cloud/blog/announcements/kubernetes-version-1-16-removes-deprecated-apis) , the current ClusterRole defined [here](https://github.com/bitnami/kube-prod-runtime/blob/d34d162c9f91f7eb3b5a73f584d226ad28bd438d/manifests/components/prometheus.jsonnet#L442l) doesn't work anymore in recent Kubernetes versions (e.g 1.16) because pod `kube-state-metrics pod` doesn't get the needed authorizations to poll metrics.