### PR TITLE
[manifests/nginx-ingress] set `proxy-buffer-size` to `16k`

### DIFF
--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -32,6 +32,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
 
   config: kube.ConfigMap($.p + "nginx-ingress") + $.metadata {
     data+: {
+      "proxy-buffer-size": "16k",
       "proxy-connect-timeout": "15",
       "disable-ipv6": "false",
 


### PR DESCRIPTION
Oauth authentication of AKS was failing after the oauth2_proxy 4.1.0 update (#671) with the error
`upstream sent too big header while reading response header from upstream` in the nginx-ingress logs.