### PR TITLE
manifests/edns: add `crd` to edns sources

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -87,7 +87,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
             edns: kube.Container("external-dns") {
               image: EXTERNAL_DNS_IMAGE,
               args_+: {
-                sources_:: ["service", "ingress"],
+                sources_:: ["service", "ingress", "crd"],
                 registry: "txt",
                 "txt-prefix": "_externaldns.",
                 "txt-owner-id": this.ownerId,


### PR DESCRIPTION
This allows BKPR users to create DNSEndpoints using the YAML files and kubectl

fe.

```yaml
apiVersion: externaldns.k8s.io/v1alpha1
kind: DNSEndpoint
metadata:
  name: my-subdomain
spec:
  endpoints:
    - dnsName: "my-subdomain.my-domain.com."
      targets:
        - "172.217.163.196"
      recordType: A
      recordTTL: 10
```