### PR TITLE
[jjo] feat: all clouds tested for 1.15-1.16, fix integration tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -192,7 +192,8 @@ def runIntegrationTest(String description, String kubeprodArgs, String ginkgoArg
 
                 withGo() {
                     dir("${env.WORKSPACE}/src/github.com/bitnami/kube-prod-runtime/tests") {
-                        sh 'go get github.com/onsi/ginkgo/ginkgo'
+                        // NOTE: ginkgo version pinned to the one used in tests/
+                        sh 'env GO111MODULE=on go get github.com/onsi/ginkgo/ginkgo@v1.12.0'
                         try {
                             sh """
                             ginkgo -v \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,7 +19,7 @@ properties([
   parameters([
     stringParam(name: 'AKS_REL', defaultValue: '1.15,1.16', description: 'AKS releases to test (comma separated)'),
     stringParam(name: 'EKS_REL', defaultValue: '1.14,1.15', description: 'EKS releases to test (comma separated)'),
-    stringParam(name: 'GKE_REL', defaultValue: '1.15,1.16-pre', description: 'GKE releases to test (comma separated)'),
+    stringParam(name: 'GKE_REL', defaultValue: '1.15,1.16', description: 'GKE releases to test (comma separated)'),
     stringParam(name: 'GEN_REL', defaultValue: '1.15', description: 'Generic-cloud releases to test (comma separated)'),
   ])
 ])

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ The following matrix shows which Kubernetes versions and platforms are supported
 | `1.3`        | `1.11`-`1.12` | `1.11`-`1.12` | `1.11`        |
 | `1.4`        | `1.14`-`1.15` | `1.14`-`1.15` | `1.14`        |
 | `1.5`        | `1.14`-`1.15` | `1.14`-`1.15` | `1.14`        |
-| `1.6`        | `1.14`-`1.16` | `1.14`-`1.15` | `1.15`        |
+| `1.6`        | `1.15`-`1.16` | `1.15`-`1.16` | `1.15`-`1.16` |
+
+Note that the (experimental) `generic` platform is e2e tested on GKE.
 
 ## Quickstart
 


### PR DESCRIPTION
* all 3 platforms now tested for 1.15 and 1.16 (GA on all),
  using 1.16 also for `generic`
* use same lock for `generic` and `gke` as they are both using
  GKE, this seems to have been the cause of flaky e2e testing results
* pin ginkgo CLI build to match `go mod` in `tests/`
* workaround https://issues.jenkins-ci.org/browse/JENKINS-41929
  to avoid the need for "2nd job run" when releases to test were changed
  from parameters properties (else it's results are confusing as they
  would stick to previous settings)