### PR TITLE
[jjo] fix: support newer jsonnet / jsonnetfmt

### DIFF
--- a/manifests/Makefile
+++ b/manifests/Makefile
@@ -1,5 +1,6 @@
 KUBECFG = kubecfg
-JSONNET_FMT = jsonnet fmt
+# Support transition from `jsonnet fmt` to `jsonnetfmt` (since v0.13+)
+JSONNET_FMT := $(shell jsonnet --version|grep -q 'v0[.]1[0-2]' && echo jsonnet fmt || echo jsonnetfmt)
 
 FMTFLAGS = \
 	--indent 2 \


### PR DESCRIPTION
Adapt manifests/Makefile to support older/current jsonnet releases,
eases local testing while not requiring an atomic update on our
jenkins-bkpr pipeline.

Note that this small change will need to be backported into active
releases branches, to let jenkins-bkpr use newer jsonnet binaries.