### PR TITLE
[jjo] fix: use fluentd suppress_type_name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,7 +247,7 @@ def runIntegrationTest(String description, String kubeprodArgs, String ginkgoArg
             container('kubectl') {
                 sh "kubectl get po,deploy,svc,ing --all-namespaces || true"
             }
-            # Below cert-manager cleanup is needed if certs issuing has failed
+            // Below cert-manager cleanup is needed if certs issuing has failed
             container('kubectl') {
                 sh """
                   timeout 60 kubectl get -n kubeprod challenges.acme.cert-manager.io -oname | \

--- a/manifests/components/fluentd-es-config/output.conf
+++ b/manifests/components/fluentd-es-config/output.conf
@@ -2,7 +2,7 @@
   @id elasticsearch
   @type elasticsearch
   @log_level info
-  type_name fluentd
+  suppress_type_name true
   include_tag_key true
   host "#{ENV['ES_HOST']}"
   port 9200

--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -8,7 +8,7 @@
     "elasticsearch-curator": "bitnami/elasticsearch-curator:5.8.1-debian-10-r85",
     "elasticsearch-exporter": "bitnami/elasticsearch-exporter:1.1.0-debian-10-r84",
     "external-dns": "bitnami/external-dns:0.7.1-debian-10-r32",
-    "fluentd": "bitnami/fluentd:1.11.1-debian-10-r0",
+    "fluentd": "bitnami/fluentd:1.11.1-debian-10-r27",
     "grafana": "bitnami/grafana:7.0.6-debian-10-r3",
     "keycloak": "jboss/keycloak:8.0.1",
     "kibana": "bitnami/kibana:7.8.0-debian-10-r2",


### PR DESCRIPTION
Fixes #878.

Elasticsearch > 7.7 deprecated `type_name`, triggering
log-spam from fluentd, use `suppress_type_name true`
with updated fluentd image.

FYI successfully dogfood-ed internally in our clusters,
to verify no logspam from fluentd, we may later want to
add a test on this (i.e. clean / empty? fluentd logs).