### PR TITLE
[jjo] fix grafana dashboard imports

### DIFF
--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -123,9 +123,9 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
   kubernetes_dashboards: utils.HashedConfigMap($.p + "grafana-kubernetes-dashboards") + $.metadata {
     local this = self,
     data+: {
-      "k8s_cluster_capacity.json": importstr "../vendor/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_cluster_capacity.json",
-      "k8s_cluster_workloads_summary.json": importstr "../vendor/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_cluster_workloads_summary.json",
-      "k8s_resource_usage_namespace_pods.json": importstr "../vendor/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json",
+      "k8s_cluster_capacity.json": importstr "../vendor/github.com/bitnami-labs/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_cluster_capacity.json",
+      "k8s_cluster_workloads_summary.json": importstr "../vendor/github.com/bitnami-labs/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_cluster_workloads_summary.json",
+      "k8s_resource_usage_namespace_pods.json": importstr "../vendor/github.com/bitnami-labs/kubernetes-grafana-dashboards/handcrafted/kubernetes/k8s_resource_usage_namespace_pods.json",
     },
   },
 


### PR DESCRIPTION
Fix grafana.jsonnet dashboard imports to use full vendored
path instead of symlink, as the latter is not present at
`releases.kubeprod.io` cloudfront bucket (we ignore symlinks
when pushing manifest tree from src to the s3 bucket).