### PR TITLE
[jjo] fix: update fluentd image for bitnami/bitnami-docker-fluentd#11

### DIFF
--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -8,7 +8,7 @@
     "elasticsearch-curator": "bitnami/elasticsearch-curator:5.8.1-debian-10-r85",
     "elasticsearch-exporter": "bitnami/elasticsearch-exporter:1.1.0-debian-10-r84",
     "external-dns": "bitnami/external-dns:0.7.1-debian-10-r32",
-    "fluentd": "bitnami/fluentd:1.11.1-debian-10-r27",
+    "fluentd": "bitnami/fluentd:1.11.1-debian-10-r34",
     "grafana": "bitnami/grafana:7.0.6-debian-10-r3",
     "keycloak": "jboss/keycloak:8.0.1",
     "kibana": "bitnami/kibana:7.8.1-debian-10-r5",


### PR DESCRIPTION
Fixing bitnami/bitnami-docker-fluentd#11 for BKPR, withdraws #897.