### PR TITLE
[jjo] fix: add `endpoints` to external-dns RBAC r/only perms

### DIFF
--- a/manifests/components/externaldns.jsonnet
+++ b/manifests/components/externaldns.jsonnet
@@ -35,7 +35,7 @@ local EXTERNAL_DNS_IMAGE = (import "images.json")["external-dns"];
     rules: [
       {
         apiGroups: [""],
-        resources: ["services", "pods", "nodes"],
+        resources: ["services", "pods", "nodes", "endpoints"],
         verbs: ["get", "list", "watch"],
       },
       {

--- a/manifests/components/images.json
+++ b/manifests/components/images.json
@@ -7,7 +7,7 @@
     "elasticsearch": "bitnami/elasticsearch:7.8.1-debian-10-r5",
     "elasticsearch-curator": "bitnami/elasticsearch-curator:5.8.1-debian-10-r85",
     "elasticsearch-exporter": "bitnami/elasticsearch-exporter:1.1.0-debian-10-r84",
-    "external-dns": "bitnami/external-dns:0.7.1-debian-10-r32",
+    "external-dns": "bitnami/external-dns:0.7.3-debian-10-r4",
     "fluentd": "bitnami/fluentd:1.11.2-debian-10-r2",
     "grafana": "bitnami/grafana:7.1.3-debian-10-r2",
     "keycloak": "jboss/keycloak:8.0.1",


### PR DESCRIPTION
Fixes #911 

Add `endpoints` to external-dns r/only RBAC perms (see https://github.com/kubernetes-sigs/external-dns/blob/master/kustomize/external-dns-clusterrole.yaml), required since 0.7.2.