### PR TITLE
[jjo] fix: oauth2-proxy >= 6.0.0 and grafana on AKS

### DIFF
--- a/manifests/components/grafana.jsonnet
+++ b/manifests/components/grafana.jsonnet
@@ -35,6 +35,8 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
       namespace: "kubeprod",
     },
   },
+  // Some platform may need to override this (AKS in particular)
+  auth_proxy_header_name:: "X-Auth-Request-User",
 
   // Amount of persistent storage required by Alertmanager
   storage:: "1Gi",
@@ -154,7 +156,7 @@ local GRAFANA_DATA_MOUNTPOINT = "/opt/bitnami/grafana/data";
               },
               env_+: {
                 GF_AUTH_PROXY_ENABLED: "true",
-                GF_AUTH_PROXY_HEADER_NAME: "X-Auth-Request-User",
+                GF_AUTH_PROXY_HEADER_NAME: $.auth_proxy_header_name,
                 GF_AUTH_PROXY_HEADER_PROPERTY: "username",
                 GF_AUTH_PROXY_HEADERS: "Email:X-Auth-Request-Email",
                 GF_AUTH_PROXY_AUTO_SIGN_UP: "true",

--- a/manifests/platforms/aks.jsonnet
+++ b/manifests/platforms/aks.jsonnet
@@ -45,6 +45,9 @@ local grafana = import "../components/grafana.jsonnet";
   version: version,
 
   grafana: grafana {
+    // oauth2-proxy >= 6.0.0 doesn't provide "X-Auth-Request-User" header on AKS,
+    // use "X-Auth-Request-Email" instead
+    auth_proxy_header_name:: "X-Auth-Request-Email",
     prometheus:: $.prometheus.prometheus.svc,
     ingress+: {
       host: "grafana." + $.external_dns_zone_name,


### PR DESCRIPTION
Fix #915.

* oauth2-proxy >= 6.0.0 on AKS doesn't provide 
  "X-Auth-Request-User" header on AKS, used by grafana
  to auto-login users, use "X-Auth-Request-Email" instead
