### PR TITLE
[jjo] release-1.7: move support window to 1.16,1.17 on all clouds (merge #921 from master)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,11 +16,13 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // corresponding parameter is set.
 // [1] see: https://issues.jenkins-ci.org/browse/JENKINS-41929
 
+// NOTE: need update below map at jenkins/cloud-custodian/Jenkinsfile
+// (until we create a common file for shared Jenkins code/data)
 def buildRelDefaults = [
-  'AKS_REL': '1.15,1.16',
-  'EKS_REL': '1.15,1.16',
-  'GKE_REL': '1.15,1.16',
-  'GEN_REL': '1.16',
+  'AKS_REL': '1.16,1.17',
+  'EKS_REL': '1.16,1.17',
+  'GKE_REL': '1.16,1.17-pre',
+  'GEN_REL': '1.16', // generic is tested on GKE, wait for 1.17 on the stable channel to change it
 ]
 
 properties([

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following matrix shows which Kubernetes versions and platforms are supported
 | `1.4`        | `1.14`-`1.15` | `1.14`-`1.15` | `1.14`        |
 | `1.5`        | `1.14`-`1.15` | `1.14`-`1.15` | `1.14`-`1.15` |
 | `1.6`        | `1.15`-`1.16` | `1.15`-`1.16` | `1.15`-`1.16` |
+| `1.7`        | `1.16`-`1.17` | `1.16`-`1.17` | `1.16`-`1.17` |
 
 Note that the (experimental) `generic` platform is e2e tested on GKE.
 
@@ -83,23 +84,23 @@ BKPR leverages the following components to achieve its mission. For more in-dept
 
 The following matrix shows which versions of each component are used and supported in the most recent releases of BKPR:
 
-|                                              Component                                               | BKPR 1.3 | BKPR 1.4 | BKPR 1.5 | BKPR 1.6 |
-|------------------------------------------------------------------------------------------------------|----------|----------|----------|----------|
-| [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/)                                    | `0.16.x` | `0.20.x` | `0.20.x` | `0.21.x` |
-| [cert-manager](https://cert-manager.io/docs/)                                                        | `0.7.x`  | `0.12.x` | `0.14.x` | `0.14.x` |
-| [configmap-reload](https://github.com/bitnami/configmap-reload)                                      | `0.2.2`  | `0.3.x`  | `0.3.x`  | `0.3.x`  |
-| [Elasticsearch](https://www.elastic.co/products/elasticsearch)                                       | `6.7.x`  | `7.5.x`  | `7.6.x`  | `7.8.x`  |
-| [Elasticsearch Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/about.html) | `5.7.x`  | `5.8.x`  | `5.8.x`  | `5.8.x`  |
-| [Elasticsearch Exporter](https://github.com/justwatchcom/elasticsearch_exporter)                     | `1.0.1`  | `1.1.x`  | `1.1.x`  | `1.1.x`  |
-| [ExternalDNS](https://github.com/kubernetes-sigs/external-dns)                                       | `0.5.x`  | `0.5.x`  | `0.7.x`  | `0.7.x`  |
-| [Fluentd](https://www.fluentd.org/)                                                                  | `1.4.x`  | `1.8.x`  | `1.10.x` | `1.11.x` |
-| [Grafana](https://grafana.com/)                                                                      | `6.5.x`  | `6.5.x`  | `6.7.x`  | `7.0.x`  |
-| [Kibana](https://www.elastic.co/products/kibana)                                                     | `6.7.x`  | `7.5.x`  | `7.6.x`  | `7.8.x`  |
-| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)                               | `1.1.0`  | `1.9.x`  | `1.9.x`  | `1.9.x`  |
-| [Node exporter](https://github.com/prometheus/node_exporter)                                         | `0.17.0` | `0.18.x` | `0.18.x` | `1.0.x`  |
-| [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx)                              | `0.24.x` | `0.26.x` | `0.30.x` | `0.33.x` |
-| [oauth2_proxy](https://github.com/pusher/oauth2_proxy)                                               | `3.1.x`  | `4.1.x`  | `5.0.x`  | `5.1.x`  |
-| [Prometheus](https://prometheus.io/)                                                                 | `2.8.x`  | `2.15.x` | `2.17.x` | `2.19.x` |
+|                                              Component                                               | BKPR 1.5 | BKPR 1.6 | BKPR 1.7 |
+|------------------------------------------------------------------------------------------------------|----------|----------|----------|
+| [Alertmanager](https://prometheus.io/docs/alerting/alertmanager/)                                    | `0.20.x` | `0.21.x` | `0.21.x` |
+| [cert-manager](https://cert-manager.io/docs/)                                                        | `0.14.x` | `0.14.x` | `0.16.x` |
+| [configmap-reload](https://github.com/bitnami/configmap-reload)                                      | `0.3.x`  | `0.3.x`  | `0.4.x`  |
+| [Elasticsearch](https://www.elastic.co/products/elasticsearch)                                       | `7.6.x`  | `7.8.x`  | `7.9.x`  |
+| [Elasticsearch Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/5.8/about.html) | `5.8.x`  | `5.8.x`  | `5.8.x`  |
+| [Elasticsearch Exporter](https://github.com/justwatchcom/elasticsearch_exporter)                     | `1.1.x`  | `1.1.x`  | `1.1.x`  |
+| [ExternalDNS](https://github.com/kubernetes-sigs/external-dns)                                       | `0.7.x`  | `0.7.x`  | `0.7.x`  |
+| [Fluentd](https://www.fluentd.org/)                                                                  | `1.10.x` | `1.11.x` | `1.11.x` |
+| [Grafana](https://grafana.com/)                                                                      | `6.7.x`  | `7.0.x`  | `7.1.x`  |
+| [Kibana](https://www.elastic.co/products/kibana)                                                     | `7.6.x`  | `7.8.x`  | `7.9.x`  |
+| [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics)                               | `1.9.x`  | `1.9.x`  | `1.9.x`  |
+| [Node exporter](https://github.com/prometheus/node_exporter)                                         | `0.18.x` | `1.0.x`  | `1.0.x`  |
+| [NGINX Ingress Controller](https://github.com/kubernetes/ingress-nginx)                              | `0.30.x` | `0.33.x` | `0.34.x` |
+| [oauth2_proxy](https://github.com/pusher/oauth2_proxy)                                               | `5.0.x`  | `5.1.x`  | `6.0.x`  |
+| [Prometheus](https://prometheus.io/)                                                                 | `2.17.x` | `2.19.x` | `2.20.x` |
 
 ## Contributing
 

--- a/jenkins/cloud-custodian/Jenkinsfile
+++ b/jenkins/cloud-custodian/Jenkinsfile
@@ -19,10 +19,12 @@ properties([
 
 // TODO (SRE): Create a common file for shared functions across different
 // BKPR Jenkins pipelines
+// This map is taken from main Jenkinsfile, extracting the Kubernetes releases
+// numbers, e.g. plain `1.17` even if main Jenkinsfile had `1.17-pre` to handle rapid/beta channels
 def buildRelDefaults = [
-  'AKS_REL': '1.15,1.16',
-  'EKS_REL': '1.15,1.16',
-  'GKE_REL': '1.15,1.16',
+  'AKS_REL': '1.16,1.17',
+  'EKS_REL': '1.16,1.17',
+  'GKE_REL': '1.16,1.17',
   'GEN_REL': '1.16',
 ]
 


### PR DESCRIPTION
Retrying #922, because AKS.