### PR TITLE
Feat: Update the default Cloud Custodian version for BKPR to 0.9.6.0 // Improve AWS policies

### DIFF
--- a/jenkins/cloud-custodian/Jenkinsfile
+++ b/jenkins/cloud-custodian/Jenkinsfile
@@ -12,7 +12,7 @@
 properties([
   pipelineTriggers([cron('59 23 * * 6')]),
   parameters([
-    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.8.46.0', description: "Cloud Custodian tool version"),
+    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.9.6.0', description: "Cloud Custodian tool version"),
     stringParam(name: 'REMOTE_BRANCH', defaultValue: 'master', description: "Remote branch to pull Cloud Custodian policies from"),
   ])
 ])

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -1,8 +1,13 @@
+# In order to troubleshoot the dependency errors in AWS when deleting
+# CloudFormation stacks (VPCs), it is needed to delete:
+# instances / subnets / security groups / inet gateways
+#
+# Ref: https://aws.amazon.com/premiumsupport/knowledge-center/troubleshoot-dependency-error-delete-vpc/
 policies:
-- name: bkpr-delete-cft-stacks
-  resource: cfn
+- name: bkpr-delete-eks-clusters
+  resource: aws.eks
   comment: |
-    Clean-up Cloud Formation Stacks created by Jenkins-BKPR
+    Clean-up EKS clusters created by Jenkins-BKPR
     for it's continuous integration tests
   filters:
     - type: value
@@ -12,10 +17,36 @@ policies:
   actions:
     - type: delete
 
-- name: bkpr-delete-eks-clusters
+- name: bkpr-delete-subnets
   resource: aws.eks
   comment: |
-    Clean-up EKS clusters created by Jenkins-BKPR
+    Clean-up temporary subnets created by Jenkins-BKPR
+    for it's continuous integration tests
+  filters:
+    - type: value
+      key: "tag:created_by"
+      value: "jenkins-bkpr"
+      op: eq
+  actions:
+    - type: delete
+
+- name: bkpr-delete-inet-gateways
+  resource: aws.eks
+  comment: |
+    Clean-up temporary internet gateways created by Jenkins-BKPR
+    for it's continuous integration tests
+  filters:
+    - type: value
+      key: "tag:created_by"
+      value: "jenkins-bkpr"
+      op: eq
+  actions:
+    - type: delete
+
+- name: bkpr-delete-cft-stacks
+  resource: cfn
+  comment: |
+    Clean-up Cloud Formation Stacks created by Jenkins-BKPR
     for it's continuous integration tests
   filters:
     - type: value

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -17,19 +17,6 @@ policies:
   actions:
     - type: delete
 
-- name: bkpr-delete-subnets
-  resource: aws.subnet
-  comment: |
-    Clean-up temporary subnets created by Jenkins-BKPR
-    for it's continuous integration tests
-  filters:
-    - type: value
-      key: "tag:created_by"
-      value: "jenkins-bkpr"
-      op: eq
-  actions:
-    - type: delete
-
 - name: bkpr-delete-inet-gateways
   resource: aws.internet-gateway
   comment: |

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -18,7 +18,7 @@ policies:
     - type: delete
 
 - name: bkpr-delete-subnets
-  resource: aws.eks
+  resource: aws.subnet
   comment: |
     Clean-up temporary subnets created by Jenkins-BKPR
     for it's continuous integration tests
@@ -31,7 +31,7 @@ policies:
     - type: delete
 
 - name: bkpr-delete-inet-gateways
-  resource: aws.eks
+  resource: aws.internet-gateway
   comment: |
     Clean-up temporary internet gateways created by Jenkins-BKPR
     for it's continuous integration tests


### PR DESCRIPTION
We were using a Cloud-Custodian release from January.
This PR updates the Custodian default version the Jenkins pipeline uses to clean-up the leftovers after the continuous testing execution.

Tests result:

```
Running the AWS Cloud Custodian policies
[Pipeline] sh
2020-09-17 09:55:36,050: custodian.policy:INFO policy:bkpr-delete-cft-stacks resource:cfn region:us-east-1 count:50 time:0.46
2020-09-17 09:55:54,755: custodian.policy:INFO policy:bkpr-delete-cft-stacks action:delete resources:50 execution_time:18.70
2020-09-17 09:55:56,031: custodian.policy:INFO policy:bkpr-delete-eks-clusters resource:aws.eks region:us-east-1 count:8 time:1.27
2020-09-17 09:55:59,089: custodian.policy:INFO policy:bkpr-delete-eks-clusters action:delete resources:8 execution_time:3.06
2020-09-17 09:56:01,048: custodian.policy:INFO policy:bkpr-delete-iam-svcaccounts resource:aws.iam-user region:us-east-1 count:0 time:1.95
```


Signed-off-by: David Barranco <dbarranco@vmware.com>