### PR TITLE
[release-1.7] Increase timeout of the Jenkins job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,7 +362,7 @@ spec:
     env.GOPATH = "/go"
 
     node(label) {
-        timeout(time: 181, unit: 'MINUTES') {
+        timeout(time: 180, unit: 'MINUTES') {
             withEnv([
                 "HOME=${env.WORKSPACE}",
                 "PATH+KUBEPROD=${env.WORKSPACE}/src/github.com/bitnami/kube-prod-runtime/kubeprod/bin",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,7 +362,7 @@ spec:
     env.GOPATH = "/go"
 
     node(label) {
-        timeout(time: 180, unit: 'MINUTES') {
+        timeout(time: 181, unit: 'MINUTES') {
             withEnv([
                 "HOME=${env.WORKSPACE}",
                 "PATH+KUBEPROD=${env.WORKSPACE}/src/github.com/bitnami/kube-prod-runtime/kubeprod/bin",

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -362,7 +362,7 @@ spec:
     env.GOPATH = "/go"
 
     node(label) {
-        timeout(time: 150, unit: 'MINUTES') {
+        timeout(time: 180, unit: 'MINUTES') {
             withEnv([
                 "HOME=${env.WORKSPACE}",
                 "PATH+KUBEPROD=${env.WORKSPACE}/src/github.com/bitnami/kube-prod-runtime/kubeprod/bin",


### PR DESCRIPTION
932: Increase timeout of the Jenkins job r=jjo a=javsalgar

We have a high amount of jobs that are failing because of timeout errors. This PR tries to bump this value as suggested by @jjo https://github.com/bitnami/kube-prod-runtime/pull/930#issuecomment-692666778

Co-authored-by: Javier J. Salmerón-García <jsalmeron@bitnami.com>