### PR TITLE
Fix: Update Custodian version to custom Bitnami container and fix/improve AWS / Google policies

### DIFF
--- a/jenkins/cloud-custodian/Jenkinsfile
+++ b/jenkins/cloud-custodian/Jenkinsfile
@@ -110,18 +110,17 @@ node('jnlp-agent-docker') {
               -e AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}", 'azure', 'eastus')
           }
 
-          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-eks-kubeprod-jenkins', accessKeyVariable: 'accessKeyId', secretKeyVariable: 'secretAccessKey']]) {
-            print "Running the AWS Cloud Custodian policies"
-            runCloudCustodian("-e AWS_ACCESS_KEY_ID=${accessKeyId} \
-              -e AWS_SECRET_ACCESS_KEY=${secretAccessKey}", 'aws', 'us-east-1')
-          }
-
-          withCredentials([file(credentialsId: 'gke-kubeprod-jenkins', variable: 'googleAppCredentials')]) {          
+          withCredentials([file(credentialsId: 'gke-kubeprod-jenkins', variable: 'googleAppCredentials')]) {
             print "Running the Google Cloud Custodian policies"
             runCloudCustodian(" -v ${googleAppCredentials}:/code/key.json \
             -e GOOGLE_APPLICATION_CREDENTIALS=/code/key.json \
             -e GOOGLE_CLOUD_PROJECT='bkprtesting'", 'google', 'us-east1')
+          }
 
+          withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: 'aws-eks-kubeprod-jenkins', accessKeyVariable: 'accessKeyId', secretKeyVariable: 'secretAccessKey']]) {
+            print "Running the AWS Cloud Custodian policies"
+            runCloudCustodian("-e AWS_ACCESS_KEY_ID=${accessKeyId} \
+              -e AWS_SECRET_ACCESS_KEY=${secretAccessKey}", 'aws', 'us-east-1')
           }
         }
       }

--- a/jenkins/cloud-custodian/Jenkinsfile
+++ b/jenkins/cloud-custodian/Jenkinsfile
@@ -12,7 +12,7 @@
 properties([
   pipelineTriggers([cron('59 23 * * 6')]),
   parameters([
-    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.9.6.0', description: "Cloud Custodian tool version"),
+    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.9.6.1', description: "Cloud Custodian tool version"),
     stringParam(name: 'REMOTE_BRANCH', defaultValue: 'master', description: "Remote branch to pull Cloud Custodian policies from"),
   ])
 ])
@@ -116,15 +116,13 @@ node('jnlp-agent-docker') {
               -e AWS_SECRET_ACCESS_KEY=${secretAccessKey}", 'aws', 'us-east-1')
           }
 
-          // This block will be commented until Cloud Custodian has the "delete" operations coded.
-
-          /* withCredentials([file(credentialsId: 'gke-kubeprod-jenkins', variable: 'googleAppCredentials')]) {          
+          withCredentials([file(credentialsId: 'gke-kubeprod-jenkins', variable: 'googleAppCredentials')]) {          
             print "Running the Google Cloud Custodian policies"
             runCloudCustodian(" -v ${googleAppCredentials}:/code/key.json \
             -e GOOGLE_APPLICATION_CREDENTIALS=/code/key.json \
             -e GOOGLE_CLOUD_PROJECT='bkprtesting'", 'google', 'us-east1')
 
-          } */
+          }
         }
       }
     })

--- a/jenkins/cloud-custodian/Jenkinsfile
+++ b/jenkins/cloud-custodian/Jenkinsfile
@@ -12,7 +12,7 @@
 properties([
   pipelineTriggers([cron('59 23 * * 6')]),
   parameters([
-    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.9.6.1', description: "Cloud Custodian tool version"),
+    stringParam(name: 'CUSTODIAN_VERSION', defaultValue: '0.9.6.2', description: "Cloud Custodian tool version"),
     stringParam(name: 'REMOTE_BRANCH', defaultValue: 'master', description: "Remote branch to pull Cloud Custodian policies from"),
   ])
 ])

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -33,7 +33,7 @@ policies:
 - name: bkpr-delete-nat-gateways
   resource: aws.nat-gateway
   comment: |
-    Clean-up created NatGateways created by CFN
+    Clean-up NatGateways created by CFN
     for the BKPR continuous integration tests
   filters:
     - type: value
@@ -42,6 +42,19 @@ policies:
       op: eq
   actions:
     - type: release
+
+- name: bkpr-delete-elb
+  resource: aws.elb
+  comment: |
+    Clean-up Elastic Load Balancers created by CFN
+    for the BKPR continuous integration tests
+  filters:
+    - type: value
+      key: "tag:kubernetes.io/service-name"
+      value: "kubeprod/nginx-ingress"
+      op: eq
+  actions:
+    - type: delete
 
 - name: bkpr-delete-inet-gateways
   resource: aws.internet-gateway

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -8,7 +8,7 @@ policies:
   resource: aws.eks
   comment: |
     Clean-up EKS clusters created by Jenkins-BKPR
-    for it's continuous integration tests
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:created_by"
@@ -21,7 +21,7 @@ policies:
   resource: aws.network-addr
   comment: |
     Release temporary IP addresses allocated by CFN
-    for the EKS cluster creation
+    for EKS clusters creation
   filters:
     - type: value
       key: "tag:created_by"
@@ -34,7 +34,7 @@ policies:
   resource: aws.nat-gateway
   comment: |
     Clean-up NatGateways created by CFN
-    for the BKPR continuous integration tests
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:created_by"
@@ -47,7 +47,7 @@ policies:
   resource: aws.elb
   comment: |
     Clean-up Elastic Load Balancers created by CFN
-    for the BKPR continuous integration tests
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:kubernetes.io/service-name"
@@ -59,8 +59,8 @@ policies:
 - name: bkpr-detach-inet-gateways
   resource: aws.internet-gateway
   comment: |
-    Clean-up temporary internet gateways created by Jenkins-BKPR
-    for it's continuous integration tests
+    Detach internet gateways created by Jenkins-BKPR
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:created_by"
@@ -72,8 +72,8 @@ policies:
 - name: bkpr-delete-security-groups
   resource: aws.security-group
   comment: |
-    Clean-up temporary internet gateways created by Jenkins-BKPR
-    for it's continuous integration tests
+    Clean-up temporary security-groups created by CFN
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:Name"
@@ -86,7 +86,7 @@ policies:
   resource: cfn
   comment: |
     Clean-up Cloud Formation Stacks created by Jenkins-BKPR
-    for it's continuous integration tests
+    for BKPR continuous integration tests
   filters:
     - type: value
       key: "tag:created_by"
@@ -95,24 +95,11 @@ policies:
   actions:
     - type: delete
 
-- name: bkpr-delete-security-groups
-  resource: aws.hostedzone
-  comment: |
-    Clean-up temporary internet gateways created by Jenkins-BKPR
-    for it's continuous integration tests
-  filters:
-    - type: value
-      op: regex
-      key: Name
-      value: '^(master|pr|trying|staging)\-.*.tests.bkpr.run.'
-  actions:
-    - type: delete
-
-- name: bkpr-delete-security-groups
+- name: bkpr-delete-iam-users
   resource: aws.iam-user
   comment: |
-    Clean-up temporary internet gateways created by Jenkins-BKPR
-    for it's continuous integration tests
+    Clean-up temporary IAM users created by Jenkins-BKPR
+    for BKPR continuous integration tests
   filters:
     - type: value
       op: regex

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -82,7 +82,6 @@ policies:
   actions:
     - type: delete
 
-
 - name: bkpr-delete-cft-stacks
   resource: cfn
   comment: |
@@ -96,3 +95,28 @@ policies:
   actions:
     - type: delete
 
+- name: bkpr-delete-security-groups
+  resource: aws.hostedzone
+  comment: |
+    Clean-up temporary internet gateways created by Jenkins-BKPR
+    for it's continuous integration tests
+  filters:
+    - type: value
+      op: regex
+      key: Name
+      value: '^(master|pr|trying|staging)\-.*.tests.bkpr.run.'
+  actions:
+    - type: delete
+
+- name: bkpr-delete-security-groups
+  resource: aws.iam-user
+  comment: |
+    Clean-up temporary internet gateways created by Jenkins-BKPR
+    for it's continuous integration tests
+  filters:
+    - type: value
+      op: regex
+      key: UserName
+      value: '^bkpr\-(pr|staging|trying|master)\-.*'
+  actions:
+    - type: delete

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -30,6 +30,19 @@ policies:
   actions:
     - type: release
 
+- name: bkpr-delete-nat-gateways
+  resource: aws.nat-gateway
+  comment: |
+    Clean-up created NatGateways created by CFN
+    for the BKPR continuous integration tests
+  filters:
+    - type: value
+      key: "tag:created_by"
+      value: "jenkins-bkpr"
+      op: eq
+  actions:
+    - type: release
+
 - name: bkpr-delete-inet-gateways
   resource: aws.internet-gateway
   comment: |

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -17,6 +17,19 @@ policies:
   actions:
     - type: delete
 
+- name: bkpr-release-public-ip-addresses
+  resource: aws.network-addr
+  comment: |
+    Release temporary IP addresses allocated by CFN
+    for the EKS cluster creation
+  filters:
+    - type: value
+      key: "tag:created_by"
+      value: "jenkins-bkpr"
+      op: eq
+  actions:
+    - type: release
+
 - name: bkpr-delete-inet-gateways
   resource: aws.internet-gateway
   comment: |

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -56,7 +56,7 @@ policies:
   actions:
     - type: delete
 
-- name: bkpr-delete-inet-gateways
+- name: bkpr-detach-inet-gateways
   resource: aws.internet-gateway
   comment: |
     Clean-up temporary internet gateways created by Jenkins-BKPR
@@ -67,7 +67,21 @@ policies:
       value: "jenkins-bkpr"
       op: eq
   actions:
+    - type: detach
+
+- name: bkpr-delete-security-groups
+  resource: aws.security-group
+  comment: |
+    Clean-up temporary internet gateways created by Jenkins-BKPR
+    for it's continuous integration tests
+  filters:
+    - type: value
+      key: "tag:Name"
+      value: '^eks-cluster-sg\-(staging|pr|trying|master)\-.*'
+      op: regex
+  actions:
     - type: delete
+
 
 - name: bkpr-delete-cft-stacks
   resource: cfn
@@ -82,15 +96,3 @@ policies:
   actions:
     - type: delete
 
-- name: bkpr-delete-iam-svcaccounts
-  resource: aws.iam-user
-  comment: |
-    Clean-up temporary serviceaccounts created by Jenkins-BKPR
-    for its continuous integration tests
-  filters:
-    - type: value
-      key: "tag:created_by"
-      value: "jenkins-bkpr"
-      op: eq
-  actions:
-    - type: delete

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -41,7 +41,7 @@ policies:
       value: "jenkins-bkpr"
       op: eq
   actions:
-    - type: release
+    - type: delete
 
 - name: bkpr-delete-elb
   resource: aws.elb

--- a/jenkins/cloud-custodian/policies/aws.yaml
+++ b/jenkins/cloud-custodian/policies/aws.yaml
@@ -29,6 +29,7 @@ policies:
       op: eq
   actions:
     - type: release
+      force: true
 
 - name: bkpr-delete-nat-gateways
   resource: aws.nat-gateway
@@ -68,6 +69,19 @@ policies:
       op: eq
   actions:
     - type: detach
+
+- name: bkpr-delete-inet-gateways
+  resource: aws.internet-gateway
+  comment: |
+    Delete internet gateways created by Jenkins-BKPR
+    for BKPR continuous integration tests
+  filters:
+    - type: value
+      key: "tag:created_by"
+      value: "jenkins-bkpr"
+      op: eq
+  actions:
+    - type: delete
 
 - name: bkpr-delete-security-groups
   resource: aws.security-group

--- a/jenkins/cloud-custodian/policies/google.yaml
+++ b/jenkins/cloud-custodian/policies/google.yaml
@@ -1,5 +1,3 @@
-# Not used at this moment. Cloud Custodian doesn't have
-# coded the "delete" operation for Google Cloud.
 policies:
 - name: bkpr-wipe-gke-clusters
   resource: gcp.gke-cluster

--- a/jenkins/cloud-custodian/policies/google.yaml
+++ b/jenkins/cloud-custodian/policies/google.yaml
@@ -8,8 +8,8 @@ policies:
     continuous integration tests.
   filters:
     - type: value
-      key: name
-      op: regex  
-      value: '^(pr-|trying-|staging-|master-)*.bkpr'
+      key: resourceLabels.created_by
+      op: eq
+      value: 'jenkins-bkpr'
   actions:
     - type: delete

--- a/jenkins/cloud-custodian/policies/google.yaml
+++ b/jenkins/cloud-custodian/policies/google.yaml
@@ -11,3 +11,16 @@ policies:
       value: 'jenkins-bkpr'
   actions:
     - type: delete
+
+- name: bkpr-wipe-gke-clusters
+  resource: gcp.disk
+  comment: |
+    Clean-up GKE pvcs by Jenkins-BKPR for its
+    continuous integration tests.
+  filters:
+    - type: value
+      key: name
+      op: regex
+      value: 'gke\-(pr\-|trying\-|staging\-).*\-pvc\-.*'
+  actions:
+    - type: delete

--- a/jenkins/cloud-custodian/policies/google.yaml
+++ b/jenkins/cloud-custodian/policies/google.yaml
@@ -10,6 +10,6 @@ policies:
     - type: value
       key: name
       op: regex  
-      value: '^(pr-|trying-|staging-)*.bkpr'
+      value: '^(pr-|trying-|staging-|master-)*.bkpr'
   actions:
     - type: delete


### PR DESCRIPTION
We have been facing some more issues related with the clean-ups in AWS related to the AWS dependency errors. 
This means that if you want to delete a VPC you must delete before:

* EC2 instances
* Security groups
* NatGateways
* Elastic IP addresses
* InternetGateways

Otherwise the AWS API will throw a dependency error.

In this PR you will also see that I am setting the 0.9.6.2 version of the Cloud-Custodian container. This version contains the latest improvements I landed in the Cloud-Custodian repository **and the `detach` operation coded for the InternetGateway**, as it is required prior deleting the VPC.
I will contribute to the project with that operation, but I wouldn't like to block all the clean-ups in the meantime.

****

Apart from the fix of the AWS policies (for hostedzones / IAM users) I have enabled the Google Cloud policies to clean-up the GKE clusters.