### PR TITLE
Change externalTrafficPolicy from Local to Cluster in nginx-ingress-controller

### DIFF
--- a/manifests/components/nginx-ingress.jsonnet
+++ b/manifests/components/nginx-ingress.jsonnet
@@ -178,7 +178,7 @@ local NGNIX_INGRESS_IMAGE = (import "images.json")["nginx-ingress-controller"];
         {name: "https", port: 443, protocol: "TCP"},
       ],
       type: "LoadBalancer",
-      externalTrafficPolicy: "Local",  // preserve source IP (where supported)
+      externalTrafficPolicy: "Cluster",  // preserve source IP (where supported)
     },
   },
 


### PR DESCRIPTION
From https://github.com/bitnami/kube-prod-runtime/issues/1059, using ExternalTrafficPolicy "Local" does not work with kube-proxy in ipvs. This PR changes it to Cluster.  