### PR TITLE
Fix: Make kubeprod resolve paths correctly on Windows

### DIFF
--- a/kubeprod/cmd/install.go
+++ b/kubeprod/cmd/install.go
@@ -22,6 +22,7 @@ package cmd
 import (
 	"fmt"
 	"regexp"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -110,6 +111,9 @@ func NewInstallSubcommand(cmd *cobra.Command, platform string, config installer.
 		return nil, fmt.Errorf("platform config path must be a file:// URL")
 	}
 	c.PlatformConfigPath = platformConfigURL.Path
+	if runtime.GOOS == "windows" {
+		c.PlatformConfigPath = c.PlatformConfigPath[1:]
+	}
 
 	c.Config, err = clientConfig.ClientConfig()
 	if err != nil {

--- a/kubeprod/pkg/installer/install.go
+++ b/kubeprod/pkg/installer/install.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	goruntime "runtime"
 
 	"github.com/bitnami/kubecfg/pkg/kubecfg"
 	"github.com/bitnami/kubecfg/utils"
@@ -170,6 +171,10 @@ func (c InstallCmd) Update(out io.Writer) error {
 	if err != nil {
 		return err
 	}
+	if goruntime.GOOS == "windows" {
+		input.Path = input.Path[1:]
+	}
+
 
 	validate := kubecfg.ValidateCmd{
 		Mapper:        c.Mapper,

--- a/kubeprod/tools/url.go
+++ b/kubeprod/tools/url.go
@@ -23,6 +23,8 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"runtime"
+	"strings"
 )
 
 func CwdURL() (*url.URL, error) {
@@ -32,6 +34,9 @@ func CwdURL() (*url.URL, error) {
 	}
 	if cwd[len(cwd)-1] != '/' {
 		cwd = cwd + "/"
+	}
+	if runtime.GOOS == "windows" {
+		cwd = strings.Replace(cwd, "\\", "/", -1)
 	}
 	return &url.URL{Scheme: "file", Path: cwd}, nil
 }


### PR DESCRIPTION
This is a fix that makes kubeprod correctly resolve `kubeprod-autogen.json` and the manifest files, as mentioned in https://github.com/bitnami/kube-prod-runtime/issues/1111. The fix works on Windows (in Git for Windows) and I can execute a full deployment.

I am partly raising this to see if the community has better suggestions for how to fix the issue. This is also for bookkeeping - we now have one documented fix to work from.

