### PR TITLE
Remove dependency on squid deployment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -357,7 +357,6 @@ spec:
               path: .docker/config.json
 """
 ) {
-    env.http_proxy = 'http://proxy.webcache:80/'  // Note curl/libcurl needs explicit :80 !
     env.PATH = "/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     env.GOPATH = "/go"
 


### PR DESCRIPTION
This commit removes the usage of a proxy for web traffic from the
containers inside the podTemplate. The URL is specifying a deployment in
the webcache namespace in the AWS-int cluster. This is a piece of
infrastructure that we do not intend to maintain.

It's not clear what value the proxy was providing to the pipeline. The
Manifest stage completes in a couple minutes. The current platform tests
are failing for OAuth/TLS issues that are likely not related to the
proxy.

If this impacts other portions of the pipeline in clear and obvious
ways, we'll look at fixing those problems without reintroducing the
proxy.

This has been tested in multiple different ways. See the task for
further details.

https://phabricator.nami.run/T39254