### PR TITLE
Testing hypothesis on parallel AKS testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,10 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
 // NOTE: need update below map at jenkins/cloud-custodian/Jenkinsfile
 // (until we create a common file for shared Jenkins code/data)
 def buildRelDefaults = [
-  'AKS_REL': '1.18,1.19',
-  'EKS_REL': '1.18,1.19',
-  'GKE_REL': '1.18,1.19',
-  'GEN_REL': '1.18', // generic is tested on GKE stable channel
+  'AKS_REL': '1.19',
+  'EKS_REL': '1.19',
+  'GKE_REL': '1.19',
+  'GEN_REL': '1.19', // generic is tested on GKE stable channel
 ]
 
 properties([


### PR DESCRIPTION
My hypothesis is that there may exist issues testing AKS in parallel.
There may exist a shared resource that results in the first env to
"obtain" this resource will succeed and the subsequent environment will
fail. Cheap to test this, so why not...

I decreased the number of K8s versions to test to minimise the length of
the pipeline and the possibility for random failures.

GEN_REL bumped to 1.19, though I'm not sure if that makes a difference.
Going to play with that setting to understand it more.