### PR TITLE
Update elasticsearch override documentation

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -54,10 +54,14 @@ The following deployment parameters are supported, tested, and will be honored a
     config:: import "kubeprod-autogen.json",
     // Place your overrides here
     elasticsearch+: {
-        replicas: 5,
+		sts+: {
+			spec+: {
+				replicas: 5
+			},
+		},
         // min_master_nodes > round(replicas / 2)
         min_master_nodes: 3,
-    }
+    },
 }
 ```
 


### PR DESCRIPTION
Hi there,

I've updated the docs for overriding the replicas count of elasticsearch because it fails with the current code snippet. The code is based on https://github.com/bitnami/kube-prod-runtime/blob/master/manifests/components/elasticsearch.jsonnet 

And I've added a comma to the end of the elasticsearch snippet.

Greetings from Germany,

Marvin